### PR TITLE
[#153] tools de parsing logs e fix prompt

### DIFF
--- a/docs/Time_3_Testes/tools-(Filipe_Matunaga)/TOOLS.md
+++ b/docs/Time_3_Testes/tools-(Filipe_Matunaga)/TOOLS.md
@@ -1,0 +1,184 @@
+# 🛠️ Documentação das Tools do Agente de Testes
+
+Este documento descreve os dois arquivos de tools criados para compor o pipeline do agente inteligente de testes e correção de código.
+
+---
+
+## Visão geral do pipeline
+
+```
+log de erro
+    ↓
+log_parser_tool.py       → parseia e estrutura a entrada do erro
+    ↓
+code_fix_prompt_tool.py  → monta o prompt para o agente corretor
+    ↓
+Agente LLM               → analisa, corrige e retorna o código
+```
+
+---
+
+## 📄 `log_parser_tool.py`
+
+Responsável por **receber linhas de log brutas e transformá-las em dados estruturados**, prontos para serem consumidos pelo restante do pipeline.
+
+### Formatos de log suportados
+
+| Formato   | Exemplo                                                                 |
+|-----------|-------------------------------------------------------------------------|
+| Padrão    | `2024-01-15T10:23:45 ERROR [auth] mensagem`                             |
+| Log4j     | `2024-01-15 10:23:45,123 ERROR com.app.Service - mensagem`              |
+| Syslog    | `Jan 15 10:23:45 host sshd[1234]: mensagem`                             |
+| Python    | `ERROR:modulo:mensagem`                                                 |
+| Nginx     | `192.168.1.1 - - [15/Jan/2024:10:23:45 +0000] "GET /api HTTP/1.1" 404` |
+| JSON      | `{"level":"ERROR","module":"auth","message":"falha"}`                   |
+| Raw       | Qualquer linha não vazia (fallback)                                     |
+
+### Estrutura de saída (`LogEntry`)
+
+Cada linha parseada retorna um dicionário com os campos:
+
+| Campo       | Descrição                                              |
+|-------------|--------------------------------------------------------|
+| `timestamp` | Data e hora do evento                                  |
+| `level`     | Nível de severidade (DEBUG, INFO, WARN, ERROR, etc.)   |
+| `module`    | Módulo ou serviço que gerou o log                      |
+| `message`   | Mensagem descritiva do evento                          |
+| `raw`       | Linha original sem alteração                           |
+| `format`    | Formato detectado (padrao, log4j, syslog, python, etc.)|
+
+### Tools disponíveis
+
+#### `parse_log_line(line)`
+Parseia uma única linha de log. Retorna um dicionário com os campos acima ou `None` se a linha estiver vazia.
+
+#### `parse_log_lines(lines)`
+Parseia uma lista de linhas. Linhas vazias são automaticamente ignoradas.
+
+#### `parse_log_text(text)`
+Parseia um bloco de texto com múltiplas linhas separadas por `\n`. Internamente chama `parse_log_lines`.
+
+#### `filter_by_level(entries, level)`
+Filtra uma lista de entradas pelo nível de severidade. Ex: retorna apenas entradas `ERROR`.
+
+#### `filter_by_module(entries, module)`
+Filtra uma lista de entradas pelo nome do módulo. Ex: retorna apenas entradas do módulo `auth`.
+
+#### `execute_tool(tool_name, tool_input)`
+Dispatcher central — executa qualquer tool pelo nome, sem precisar importá-la diretamente.
+
+```python
+from log_parser_tool import execute_tool
+
+entry = execute_tool("parse_log_line", {
+    "line": "2024-01-15T10:23:45 ERROR [auth] Failed to connect"
+})
+# → {"timestamp": "2024-01-15T10:23:45", "level": "ERROR", "module": "auth", ...}
+```
+
+---
+
+## 📄 `code_fix_prompt_tool.py`
+
+Responsável por **receber a descrição de um erro e montar um prompt estruturado** para ser enviado a um agente LLM de correção de código.
+
+### Estrutura do prompt gerado
+
+O prompt é dividido em seções bem delimitadas:
+
+| Seção                    | Conteúdo                                                                 |
+|--------------------------|--------------------------------------------------------------------------|
+| 🎯 Papel                 | Define o papel do agente corretor e suas responsabilidades               |
+| 🐛 Erro reportado        | A descrição do erro ou traceback                                         |
+| 📄 Código original       | O código-fonte que precisa ser corrigido *(opcional)*                    |
+| 🧪 Testes que falharam   | O código dos testes que falharam *(opcional)*                            |
+| 📌 Contexto adicional    | Informações extras sobre o comportamento esperado *(opcional)*           |
+| 📋 Instruções            | Regras que o agente deve seguir ao corrigir                              |
+| 📤 Formato de saída      | Estrutura esperada da resposta: causa, linhas modificadas e código       |
+
+### Formato de saída esperado pelo agente corretor
+
+```
+**Causa do erro:** <explicação curta>
+
+**Linhas modificadas:**
+**Código corrigido:**
+\`\`\`python
+<código corrigido aqui>
+\`\`\`
+```
+
+### Tools disponíveis
+
+#### `build_fix_prompt_from_error(error_description, original_code?, test_code?, context?, language?)`
+Gera o prompt a partir de uma descrição textual do erro (mensagem de exceção ou traceback).
+
+```python
+from code_fix_prompt_tool import execute_tool
+
+result = execute_tool("build_fix_prompt_from_error", {
+    "error_description": "AssertionError: assert entry.module == 'auth'",
+    "original_code": "def parse_python(raw): ...",
+    "test_code": "def test_modulo(): assert entry.module == 'auth'",
+})
+
+print(result["prompt"])    # prompt pronto para enviar ao LLM
+print(result["metadata"])  # informações sobre o que foi incluído
+```
+
+#### `build_fix_prompt_from_log_entry(log_entry, original_code?, test_code?, language?)`
+Gera o prompt a partir de uma entrada de log já parseada — encadeia diretamente com `log_parser_tool`.
+
+```python
+from log_parser_tool import execute_tool as log_tool
+from code_fix_prompt_tool import execute_tool as fix_tool
+
+entry = log_tool("parse_log_line", {
+    "line": "ERROR:auth:Failed to connect"
+})
+
+result = fix_tool("build_fix_prompt_from_log_entry", {
+    "log_entry": entry,
+    "original_code": "def parse_python(raw): ...",
+})
+
+print(result["prompt"])
+```
+
+#### `execute_tool(tool_name, tool_input)`
+Dispatcher central — mesmo padrão do `log_parser_tool`.
+
+---
+
+## 🔗 Usando os dois arquivos juntos
+
+```python
+from log_parser_tool import execute_tool as log_tool
+from code_fix_prompt_tool import execute_tool as fix_tool
+
+# 1. Parseia o log de erro
+entry = log_tool("parse_log_line", {
+    "line": "2024-01-15T10:23:45 ERROR [auth] Failed to connect to DB"
+})
+
+# 2. Gera o prompt para o agente corretor
+result = fix_tool("build_fix_prompt_from_log_entry", {
+    "log_entry": entry,
+    "original_code": "...",
+    "test_code": "...",
+})
+
+# 3. Envia o prompt para o LLM (ex: API do Claude)
+prompt = result["prompt"]
+```
+
+---
+
+## 📦 Dependências
+
+Nenhuma dependência externa. Ambos os arquivos usam apenas a biblioteca padrão do Python:
+
+- `re` — expressões regulares para os parsers
+- `json` — parse de logs em formato JSON
+- `dataclasses` — estrutura `LogEntry`
+- `typing` — anotações de tipo (`Optional`)

--- a/docs/Time_3_Testes/tools-(Filipe_Matunaga)/build_fix_prompt.py
+++ b/docs/Time_3_Testes/tools-(Filipe_Matunaga)/build_fix_prompt.py
@@ -1,0 +1,291 @@
+from typing import Optional
+ 
+ 
+# ── builders de prompt ────────────────────────────────────────────────────────
+ 
+def _secao(titulo: str, conteudo: str) -> str:
+    """Formata uma seção do prompt com título e conteúdo."""
+    linha = "─" * 60
+    return f"{linha}\n{titulo}\n{linha}\n{conteudo.strip()}\n"
+ 
+ 
+def build_fix_prompt(
+    error_description: str,
+    original_code: Optional[str] = None,
+    test_code: Optional[str] = None,
+    context: Optional[str] = None,
+    language: str = "Python",
+) -> str:
+    """
+    Constrói um prompt estruturado para um agente de correção de código.
+ 
+    Recebe a descrição do erro (e opcionalmente o código original, os testes
+    que falharam e contexto adicional) e monta um prompt completo pronto para
+    ser enviado a outro agente LLM.
+ 
+    Parâmetros:
+        error_description (str): Descrição do erro ou traceback capturado.
+        original_code (str, optional): Código que precisa ser corrigido.
+        test_code (str, optional): Código dos testes que falharam.
+        context (str, optional): Informações adicionais de contexto (ex: comportamento esperado).
+        language (str): Linguagem de programação do código. Padrão: "Python".
+ 
+    Retorna:
+        str: Prompt estruturado pronto para ser enviado ao agente de correção.
+    """
+    secoes = []
+ 
+    secoes.append(_secao(
+        "🎯 PAPEL",
+        (
+            f"Você é um agente especialista em correção de código {language}. "
+            "Sua tarefa é analisar o erro reportado, entender a causa raiz e "
+            "reescrever o código corrigido — mantendo a lógica original intacta "
+            "e garantindo que todos os testes passem."
+            "Se não conseguir identificar com totalidade a parte do código que produz o erro, não tente mudar o código, mas produza um doubt artifact para revisão humana"
+        )
+    ))
+ 
+    # Erro
+    secoes.append(_secao(
+        "🐛 ERRO REPORTADO",
+        error_description
+    ))
+ 
+    # Código original (se fornecido)
+    if original_code:
+        secoes.append(_secao(
+            "📄 CÓDIGO ORIGINAL",
+            f"```{language.lower()}\n{original_code}\n```"
+        ))
+ 
+    # Testes que falharam (se fornecidos)
+    if test_code:
+        secoes.append(_secao(
+            "🧪 TESTES QUE FALHARAM",
+            f"```{language.lower()}\n{test_code}\n```"
+        ))
+ 
+    # Contexto adicional (se fornecido)
+    if context:
+        secoes.append(_secao(
+            "📌 CONTEXTO ADICIONAL",
+            context
+        ))
+ 
+    # Instruções de saída
+    secoes.append(_secao(
+        "📋 INSTRUÇÕES",
+        (
+            "1. Identifique a causa raiz do erro com base nas informações acima.\n"
+            "2. Explique brevemente o que estava errado (máximo 3 linhas).\n"
+            "3. Reescreva APENAS o trecho ou função que precisa ser corrigido.\n"
+            "4. Não altere partes do código que não estão relacionadas ao erro.\n"
+            "5. Garanta que o código corrigido seja compatível com os testes fornecidos.\n"
+            "6. Retorne o código corrigido dentro de um bloco de código com a linguagem especificada."
+        )
+    ))
+ 
+    # Formato de saída esperado
+    secoes.append(_secao(
+        "📤 FORMATO DE SAÍDA ESPERADO",
+        (
+            "**Causa do erro:** <explicação curta>\n\n"
+            "**Linhas modificadas:**\n"
+            f"**Código corrigido:**\n"
+            f"```{language.lower()}\n"
+            "<código corrigido aqui>\n"
+            "```"
+        )
+    ))
+ 
+    return "\n".join(secoes)
+ 
+ 
+# ── funções de tool ───────────────────────────────────────────────────────────
+ 
+def build_fix_prompt_from_error(
+    error_description: str,
+    original_code: Optional[str] = None,
+    test_code: Optional[str] = None,
+    context: Optional[str] = None,
+    language: str = "Python",
+) -> dict:
+    """
+    Gera um prompt estruturado para um agente de correção de código a partir
+    da descrição de um erro.
+ 
+    Parâmetros:
+        error_description (str): Descrição do erro, mensagem de exceção ou traceback.
+        original_code (str, optional): Código-fonte que precisa ser corrigido.
+        test_code (str, optional): Código dos testes que falharam.
+        context (str, optional): Contexto adicional sobre o comportamento esperado.
+        language (str): Linguagem de programação. Padrão: "Python".
+ 
+    Retorna:
+        dict com:
+            - prompt (str): Prompt estruturado pronto para envio ao agente.
+            - metadata (dict): Informações sobre o que foi incluído no prompt.
+    """
+    prompt = build_fix_prompt(
+        error_description=error_description,
+        original_code=original_code,
+        test_code=test_code,
+        context=context,
+        language=language,
+    )
+ 
+    return {
+        "prompt": prompt,
+        "metadata": {
+            "language": language,
+            "has_original_code": original_code is not None,
+            "has_test_code": test_code is not None,
+            "has_context": context is not None,
+            "prompt_length": len(prompt),
+        }
+    }
+ 
+ 
+def build_fix_prompt_from_log_entry(
+    log_entry: dict,
+    original_code: Optional[str] = None,
+    test_code: Optional[str] = None,
+    language: str = "Python",
+) -> dict:
+    """
+    Gera um prompt estruturado para um agente de correção de código a partir
+    de uma entrada de log já parseada (retornada por parse_log_line ou parse_log_lines).
+ 
+    Útil para encadear diretamente com as tools do log_parser_tool.
+ 
+    Parâmetros:
+        log_entry (dict): Entrada de log com os campos: level, module, message, timestamp, raw.
+        original_code (str, optional): Código-fonte que precisa ser corrigido.
+        test_code (str, optional): Código dos testes que falharam.
+        language (str): Linguagem de programação. Padrão: "Python".
+ 
+    Retorna:
+        dict com:
+            - prompt (str): Prompt estruturado pronto para envio ao agente.
+            - metadata (dict): Informações sobre o que foi incluído no prompt.
+    """
+    error_description = (
+        f"Nível:     {log_entry.get('level', 'UNKNOWN')}\n"
+        f"Módulo:    {log_entry.get('module', 'unknown')}\n"
+        f"Timestamp: {log_entry.get('timestamp', 'unknown')}\n"
+        f"Mensagem:  {log_entry.get('message', '')}\n"
+        f"Raw:       {log_entry.get('raw', '')}"
+    )
+ 
+    context = f"Formato do log detectado: {log_entry.get('format', 'unknown')}"
+ 
+    return build_fix_prompt_from_error(
+        error_description=error_description,
+        original_code=original_code,
+        test_code=test_code,
+        context=context,
+        language=language,
+    )
+ 
+ 
+# ── definição das tools para o agente ────────────────────────────────────────
+ 
+CODE_FIX_PROMPT_TOOLS = [
+    {
+        "name": "build_fix_prompt_from_error",
+        "description": (
+            "Gera um prompt estruturado para um agente de correção de código "
+            "a partir da descrição textual de um erro. "
+            "O prompt resultante instrui o agente a identificar a causa raiz, "
+            "explicar o problema e reescrever o código corrigido. "
+            "Use quando tiver a mensagem de erro ou traceback em formato de texto."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "error_description": {
+                    "type": "string",
+                    "description": (
+                        "Descrição do erro, mensagem de exceção ou traceback completo. "
+                        "Ex: 'AssertionError: assert entry.module == \"auth\"' ou "
+                        "um traceback completo do pytest."
+                    )
+                },
+                "original_code": {
+                    "type": "string",
+                    "description": "Código-fonte que precisa ser corrigido (opcional)."
+                },
+                "test_code": {
+                    "type": "string",
+                    "description": "Código dos testes que falharam (opcional)."
+                },
+                "context": {
+                    "type": "string",
+                    "description": "Contexto adicional sobre o comportamento esperado (opcional)."
+                },
+                "language": {
+                    "type": "string",
+                    "description": "Linguagem de programação do código. Padrão: 'Python'."
+                }
+            },
+            "required": ["error_description"]
+        },
+        "function": build_fix_prompt_from_error,
+    },
+    {
+        "name": "build_fix_prompt_from_log_entry",
+        "description": (
+            "Gera um prompt estruturado para um agente de correção de código "
+            "a partir de uma entrada de log já parseada. "
+            "Encadeia diretamente com as tools do log_parser_tool — "
+            "passe o dict retornado por parse_log_line como log_entry. "
+            "Use quando o erro vier de um log estruturado."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "log_entry": {
+                    "type": "object",
+                    "description": (
+                        "Entrada de log parseada com os campos: "
+                        "level, module, message, timestamp, raw, format. "
+                        "Retornada por parse_log_line ou parse_log_lines."
+                    )
+                },
+                "original_code": {
+                    "type": "string",
+                    "description": "Código-fonte que precisa ser corrigido (opcional)."
+                },
+                "test_code": {
+                    "type": "string",
+                    "description": "Código dos testes que falharam (opcional)."
+                },
+                "language": {
+                    "type": "string",
+                    "description": "Linguagem de programação do código. Padrão: 'Python'."
+                }
+            },
+            "required": ["log_entry"]
+        },
+        "function": build_fix_prompt_from_log_entry,
+    },
+]
+ 
+ 
+def execute_tool(tool_name: str, tool_input: dict):
+    """
+    Executa uma tool pelo nome, passando os inputs necessários.
+    Use essa função no loop do agente para despachar chamadas de tool.
+ 
+    Exemplo:
+        result = execute_tool("build_fix_prompt_from_error", {
+            "error_description": "AssertionError: assert entry.module == 'auth'",
+            "original_code": "def parse_line(raw): ...",
+            "test_code": "def test_modulo(entry): assert entry.module == 'auth'",
+        })
+    """
+    for tool in CODE_FIX_PROMPT_TOOLS:
+        if tool["name"] == tool_name:
+            return tool["function"](**tool_input)
+    raise ValueError(f"Tool '{tool_name}' não encontrada.")

--- a/docs/Time_3_Testes/tools-(Filipe_Matunaga)/log_parser_tool.py
+++ b/docs/Time_3_Testes/tools-(Filipe_Matunaga)/log_parser_tool.py
@@ -1,0 +1,404 @@
+import re
+import json
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+
+@dataclass
+class LogEntry:
+    timestamp: str
+    level: str
+    module: str
+    message: str
+    raw: str
+    format: str = "unknown"
+
+
+# ── parsers por formato ───────────────────────────────────────────────────────
+
+PATTERN_PADRAO = re.compile(
+    r"(?P<timestamp>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})"
+    r"\s+(?P<level>DEBUG|INFO|WARN(?:ING)?|ERROR|CRITICAL|FATAL)"
+    r"(?:\s+\[(?P<module>[^\]]+)\])?"
+    r"\s+(?P<message>.+)"
+)
+
+PATTERN_LOG4J = re.compile(
+    r"(?P<timestamp>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}),\d+"
+    r"\s+(?P<level>DEBUG|INFO|WARN(?:ING)?|ERROR|CRITICAL|FATAL)"
+    r"\s+(?P<module>\S+)"
+    r"\s+-\s+(?P<message>.+)"
+)
+
+PATTERN_SYSLOG = re.compile(
+    r"(?P<timestamp>[A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})"
+    r"\s+\S+"
+    r"\s+(?P<module>\S+?)(?:\[\d+\])?"
+    r":\s+(?P<message>.+)"
+)
+
+PATTERN_PYTHON = re.compile(
+    r"(?P<level>DEBUG|INFO|WARN(?:ING)?|ERROR|CRITICAL|FATAL)"
+    r":(?P<module>[^:]+)"
+    r":(?P<message>.+)"
+)
+
+PATTERN_NGINX = re.compile(
+    r"(?P<module>\S+)"
+    r"\s+-\s+-\s+"
+    r"\[(?P<timestamp>\d{2}/\w+/\d{4}:\d{2}:\d{2}:\d{2}\s+[+-]\d{4})\]"
+    r'\s+"(?P<message>[^"]+)"'
+    r"\s+(?P<status>\d{3})"
+    r"\s+\d+"
+)
+
+NIVEL_HTTP = {
+    "1": "INFO", "2": "INFO", "3": "INFO",
+    "4": "ERROR", "5": "CRITICAL"
+}
+
+
+def _nivel_nginx(status: str) -> str:
+    return NIVEL_HTTP.get(status[0], "INFO")
+
+
+def parse_padrao(raw: str) -> Optional[LogEntry]:
+    m = PATTERN_PADRAO.match(raw.strip())
+    if not m:
+        return None
+    return LogEntry(
+        timestamp=m.group("timestamp"),
+        level=m.group("level"),
+        module=m.group("module") or "unknown",
+        message=m.group("message"),
+        raw=raw.strip(),
+        format="padrao",
+    )
+
+
+def parse_log4j(raw: str) -> Optional[LogEntry]:
+    m = PATTERN_LOG4J.match(raw.strip())
+    if not m:
+        return None
+    return LogEntry(
+        timestamp=m.group("timestamp"),
+        level=m.group("level"),
+        module=m.group("module"),
+        message=m.group("message"),
+        raw=raw.strip(),
+        format="log4j",
+    )
+
+
+def parse_syslog(raw: str) -> Optional[LogEntry]:
+    m = PATTERN_SYSLOG.match(raw.strip())
+    if not m:
+        return None
+    return LogEntry(
+        timestamp=m.group("timestamp"),
+        level="INFO",
+        module=m.group("module"),
+        message=m.group("message"),
+        raw=raw.strip(),
+        format="syslog",
+    )
+
+
+def parse_python(raw: str) -> Optional[LogEntry]:
+    m = PATTERN_PYTHON.match(raw.strip())
+    if not m:
+        return None
+    return LogEntry(
+        timestamp="unknown",
+        level=m.group("level"),
+        module=m.group("module"),
+        message=m.group("message"),
+        raw=raw.strip(),
+        format="python",
+    )
+
+
+def parse_nginx(raw: str) -> Optional[LogEntry]:
+    m = PATTERN_NGINX.match(raw.strip())
+    if not m:
+        return None
+    status = m.group("status")
+    return LogEntry(
+        timestamp=m.group("timestamp"),
+        level=_nivel_nginx(status),
+        module=m.group("module"),
+        message=m.group("message"),
+        raw=raw.strip(),
+        format="nginx",
+    )
+
+
+def parse_json_log(raw: str) -> Optional[LogEntry]:
+    stripped = raw.strip()
+    if not stripped.startswith("{"):
+        return None
+    try:
+        d = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+
+    message = d.get("message") or d.get("msg") or d.get("text") or ""
+    level   = d.get("level")   or d.get("severity") or d.get("lvl") or "INFO"
+    module  = d.get("module")  or d.get("logger")   or d.get("service") or "unknown"
+    ts      = d.get("timestamp") or d.get("time")   or d.get("ts") or "unknown"
+
+    if not message:
+        return None
+
+    return LogEntry(
+        timestamp=str(ts),
+        level=level.upper(),
+        module=str(module),
+        message=str(message),
+        raw=stripped,
+        format="json",
+    )
+
+
+def parse_raw(raw: str) -> Optional[LogEntry]:
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    return LogEntry(
+        timestamp="unknown",
+        level="UNKNOWN",
+        module="unknown",
+        message=stripped,
+        raw=stripped,
+        format="raw",
+    )
+
+
+PARSERS = [
+    parse_json_log,
+    parse_log4j,
+    parse_padrao,
+    parse_nginx,
+    parse_syslog,
+    parse_python,
+    parse_raw,
+]
+
+
+def parse_line(raw: str) -> Optional[LogEntry]:
+    for parser in PARSERS:
+        entry = parser(raw)
+        if entry is not None:
+            return entry
+    return None
+
+
+# ── tool para agente de testes ────────────────────────────────────────────────
+
+def parse_log_line(line: str) -> dict:
+    """
+    Faz o parse de uma única linha de log e retorna um dicionário com os campos extraídos.
+
+    Parâmetros:
+        line (str): Uma linha de log em qualquer formato suportado
+                    (padrão, log4j, syslog, python, nginx, json, raw).
+
+    Retorna:
+        dict com os campos: timestamp, level, module, message, raw, format.
+        Retorna None se a linha estiver vazia.
+
+    Formatos suportados:
+        - padrão:  2024-01-15T10:23:45 ERROR [auth] mensagem
+        - log4j:   2024-01-15 10:23:45,123 ERROR com.app.Service - mensagem
+        - syslog:  Jan 15 10:23:45 host sshd[1234]: mensagem
+        - python:  ERROR:modulo:mensagem
+        - nginx:   IP - - [timestamp] "GET /path HTTP/1.1" 404 512
+        - json:    {"level":"ERROR","module":"auth","message":"falha"}
+        - raw:     qualquer outra linha não vazia (fallback)
+    """
+    entry = parse_line(line)
+    if entry is None:
+        return None
+    return asdict(entry)
+
+
+def parse_log_lines(lines: list[str]) -> list[dict]:
+    """
+    Faz o parse de uma lista de linhas de log.
+
+    Parâmetros:
+        lines (list[str]): Lista de linhas de log.
+
+    Retorna:
+        Lista de dicionários com os campos de cada entrada.
+        Linhas vazias são ignoradas (não aparecem no resultado).
+    """
+    results = []
+    for line in lines:
+        entry = parse_log_line(line)
+        if entry is not None:
+            results.append(entry)
+    return results
+
+
+def parse_log_text(text: str) -> list[dict]:
+    """
+    Faz o parse de um bloco de texto com múltiplas linhas de log.
+
+    Parâmetros:
+        text (str): Texto completo com várias linhas de log.
+
+    Retorna:
+        Lista de dicionários com os campos de cada entrada parseada.
+    """
+    return parse_log_lines(text.splitlines())
+
+
+def filter_by_level(entries: list[dict], level: str) -> list[dict]:
+    """
+    Filtra entradas de log por nível de severidade.
+
+    Parâmetros:
+        entries (list[dict]): Lista de entradas retornadas por parse_log_lines ou parse_log_text.
+        level (str): Nível desejado (ex: "ERROR", "INFO", "WARN", "CRITICAL").
+
+    Retorna:
+        Lista filtrada com apenas as entradas do nível especificado.
+    """
+    return [e for e in entries if e["level"].upper() == level.upper()]
+
+
+def filter_by_module(entries: list[dict], module: str) -> list[dict]:
+    """
+    Filtra entradas de log por módulo.
+
+    Parâmetros:
+        entries (list[dict]): Lista de entradas retornadas por parse_log_lines ou parse_log_text.
+        module (str): Nome do módulo (ex: "auth", "db", "api").
+
+    Retorna:
+        Lista filtrada com apenas as entradas do módulo especificado.
+    """
+    return [e for e in entries if e["module"] == module]
+
+
+# ── definição da tool para o agente ──────────────────────────────────────────
+
+LOG_PARSER_TOOLS = [
+    {
+        "name": "parse_log_line",
+        "description": (
+            "Faz o parse de uma única linha de log e retorna os campos extraídos "
+            "(timestamp, level, module, message, format). "
+            "Suporta os formatos: padrão, log4j, syslog, python logging, nginx/apache, JSON e raw. "
+            "Use quando precisar analisar uma linha isolada de log em um teste."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "line": {
+                    "type": "string",
+                    "description": "A linha de log a ser parseada."
+                }
+            },
+            "required": ["line"]
+        },
+        "function": parse_log_line,
+    },
+    {
+        "name": "parse_log_lines",
+        "description": (
+            "Faz o parse de uma lista de linhas de log e retorna uma lista de entradas estruturadas. "
+            "Linhas vazias são ignoradas. "
+            "Use quando precisar processar múltiplas linhas individualmente em um teste."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "lines": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Lista de linhas de log."
+                }
+            },
+            "required": ["lines"]
+        },
+        "function": parse_log_lines,
+    },
+    {
+        "name": "parse_log_text",
+        "description": (
+            "Faz o parse de um bloco de texto com múltiplas linhas de log. "
+            "Use quando o log estiver em formato de texto corrido com quebras de linha."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "Bloco de texto com as linhas de log separadas por quebras de linha."
+                }
+            },
+            "required": ["text"]
+        },
+        "function": parse_log_text,
+    },
+    {
+        "name": "filter_by_level",
+        "description": (
+            "Filtra uma lista de entradas de log por nível de severidade (ex: ERROR, INFO, WARN). "
+            "Use após parse_log_lines ou parse_log_text para isolar entradas de um nível específico."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "description": "Lista de entradas de log (dicionários retornados pelo parser)."
+                },
+                "level": {
+                    "type": "string",
+                    "description": "Nível de log desejado. Ex: 'ERROR', 'INFO', 'WARN', 'CRITICAL'."
+                }
+            },
+            "required": ["entries", "level"]
+        },
+        "function": filter_by_level,
+    },
+    {
+        "name": "filter_by_module",
+        "description": (
+            "Filtra uma lista de entradas de log por nome de módulo. "
+            "Use após parse_log_lines ou parse_log_text para isolar entradas de um módulo específico."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "description": "Lista de entradas de log (dicionários retornados pelo parser)."
+                },
+                "module": {
+                    "type": "string",
+                    "description": "Nome do módulo desejado. Ex: 'auth', 'db', 'api'."
+                }
+            },
+            "required": ["entries", "module"]
+        },
+        "function": filter_by_module,
+    },
+]
+
+
+def execute_tool(tool_name: str, tool_input: dict):
+    """
+    Executa uma tool pelo nome, passando os inputs necessários.
+    Use essa função no loop do agente para despachar chamadas de tool.
+
+    Exemplo:
+        result = execute_tool("parse_log_line", {"line": "2024-01-15T10:23:45 ERROR [auth] falha"})
+    """
+    for tool in LOG_PARSER_TOOLS:
+        if tool["name"] == tool_name:
+            return tool["function"](**tool_input)
+    raise ValueError(f"Tool '{tool_name}' não encontrada.")


### PR DESCRIPTION
# 🛠️ Documentação das Tools do Agente de Testes

Este documento descreve os dois arquivos de tools criados para compor o pipeline do agente inteligente de testes e correção de código.

---

## Visão geral do pipeline

```
log de erro
    ↓
log_parser_tool.py       → parseia e estrutura a entrada do erro
    ↓
code_fix_prompt_tool.py  → monta o prompt para o agente corretor
    ↓
Agente LLM               → analisa, corrige e retorna o código
```

---

## 📄 `log_parser_tool.py`

Responsável por **receber linhas de log brutas e transformá-las em dados estruturados**, prontos para serem consumidos pelo restante do pipeline.

### Formatos de log suportados

| Formato   | Exemplo                                                                 |
|-----------|-------------------------------------------------------------------------|
| Padrão    | `2024-01-15T10:23:45 ERROR [auth] mensagem`                             |
| Log4j     | `2024-01-15 10:23:45,123 ERROR com.app.Service - mensagem`              |
| Syslog    | `Jan 15 10:23:45 host sshd[1234]: mensagem`                             |
| Python    | `ERROR:modulo:mensagem`                                                 |
| Nginx     | `192.168.1.1 - - [15/Jan/2024:10:23:45 +0000] "GET /api HTTP/1.1" 404` |
| JSON      | `{"level":"ERROR","module":"auth","message":"falha"}`                   |
| Raw       | Qualquer linha não vazia (fallback)                                     |

### Estrutura de saída (`LogEntry`)

Cada linha parseada retorna um dicionário com os campos:

| Campo       | Descrição                                              |
|-------------|--------------------------------------------------------|
| `timestamp` | Data e hora do evento                                  |
| `level`     | Nível de severidade (DEBUG, INFO, WARN, ERROR, etc.)   |
| `module`    | Módulo ou serviço que gerou o log                      |
| `message`   | Mensagem descritiva do evento                          |
| `raw`       | Linha original sem alteração                           |
| `format`    | Formato detectado (padrao, log4j, syslog, python, etc.)|

### Tools disponíveis

#### `parse_log_line(line)`
Parseia uma única linha de log. Retorna um dicionário com os campos acima ou `None` se a linha estiver vazia.

#### `parse_log_lines(lines)`
Parseia uma lista de linhas. Linhas vazias são automaticamente ignoradas.

#### `parse_log_text(text)`
Parseia um bloco de texto com múltiplas linhas separadas por `\n`. Internamente chama `parse_log_lines`.

#### `filter_by_level(entries, level)`
Filtra uma lista de entradas pelo nível de severidade. Ex: retorna apenas entradas `ERROR`.

#### `filter_by_module(entries, module)`
Filtra uma lista de entradas pelo nome do módulo. Ex: retorna apenas entradas do módulo `auth`.

#### `execute_tool(tool_name, tool_input)`
Dispatcher central — executa qualquer tool pelo nome, sem precisar importá-la diretamente.

```python
from log_parser_tool import execute_tool

entry = execute_tool("parse_log_line", {
    "line": "2024-01-15T10:23:45 ERROR [auth] Failed to connect"
})
# → {"timestamp": "2024-01-15T10:23:45", "level": "ERROR", "module": "auth", ...}
```

---

## 📄 `code_fix_prompt_tool.py`

Responsável por **receber a descrição de um erro e montar um prompt estruturado** para ser enviado a um agente LLM de correção de código.

### Estrutura do prompt gerado

O prompt é dividido em seções bem delimitadas:

| Seção                    | Conteúdo                                                                 |
|--------------------------|--------------------------------------------------------------------------|
| 🎯 Papel                 | Define o papel do agente corretor e suas responsabilidades               |
| 🐛 Erro reportado        | A descrição do erro ou traceback                                         |
| 📄 Código original       | O código-fonte que precisa ser corrigido *(opcional)*                    |
| 🧪 Testes que falharam   | O código dos testes que falharam *(opcional)*                            |
| 📌 Contexto adicional    | Informações extras sobre o comportamento esperado *(opcional)*           |
| 📋 Instruções            | Regras que o agente deve seguir ao corrigir                              |
| 📤 Formato de saída      | Estrutura esperada da resposta: causa, linhas modificadas e código       |

### Formato de saída esperado pelo agente corretor

```
**Causa do erro:** <explicação curta>

**Linhas modificadas:**
**Código corrigido:**
\`\`\`python
<código corrigido aqui>
\`\`\`
```

### Tools disponíveis

#### `build_fix_prompt_from_error(error_description, original_code?, test_code?, context?, language?)`
Gera o prompt a partir de uma descrição textual do erro (mensagem de exceção ou traceback).

```python
from code_fix_prompt_tool import execute_tool

result = execute_tool("build_fix_prompt_from_error", {
    "error_description": "AssertionError: assert entry.module == 'auth'",
    "original_code": "def parse_python(raw): ...",
    "test_code": "def test_modulo(): assert entry.module == 'auth'",
})

print(result["prompt"])    # prompt pronto para enviar ao LLM
print(result["metadata"])  # informações sobre o que foi incluído
```

#### `build_fix_prompt_from_log_entry(log_entry, original_code?, test_code?, language?)`
Gera o prompt a partir de uma entrada de log já parseada — encadeia diretamente com `log_parser_tool`.

```python
from log_parser_tool import execute_tool as log_tool
from code_fix_prompt_tool import execute_tool as fix_tool

entry = log_tool("parse_log_line", {
    "line": "ERROR:auth:Failed to connect"
})

result = fix_tool("build_fix_prompt_from_log_entry", {
    "log_entry": entry,
    "original_code": "def parse_python(raw): ...",
})

print(result["prompt"])
```

#### `execute_tool(tool_name, tool_input)`
Dispatcher central — mesmo padrão do `log_parser_tool`.

---

## 🔗 Usando os dois arquivos juntos

```python
from log_parser_tool import execute_tool as log_tool
from code_fix_prompt_tool import execute_tool as fix_tool

# 1. Parseia o log de erro
entry = log_tool("parse_log_line", {
    "line": "2024-01-15T10:23:45 ERROR [auth] Failed to connect to DB"
})

# 2. Gera o prompt para o agente corretor
result = fix_tool("build_fix_prompt_from_log_entry", {
    "log_entry": entry,
    "original_code": "...",
    "test_code": "...",
})

# 3. Envia o prompt para o LLM (ex: API do Claude)
prompt = result["prompt"]
```

---

## 📦 Dependências

Nenhuma dependência externa. Ambos os arquivos usam apenas a biblioteca padrão do Python:

- `re` — expressões regulares para os parsers
- `json` — parse de logs em formato JSON
- `dataclasses` — estrutura `LogEntry`
- `typing` — anotações de tipo (`Optional`)
