### PR TITLE
feat(workspace): centralize agent output dir via WORKSPACE_OUTPUT_DIR…

### DIFF
--- a/adk/.env.example
+++ b/adk/.env.example
@@ -3,10 +3,16 @@
 ADK_LLM_MODEL=github_copilot/gpt-4
 
 # Diretório de discovery de apps ADK.
-# Produção (default): runners
-# Desenvolvimento: agents/roles
-ADK_AGENTS_DIR=runners
+ADK_AGENTS_DIR=src/agents
 
 # Diretório base para resolução de caminhos relativos das tools do agente de requisitos.
 # Aponta para agents/roles/requirements/ a partir do CWD (adk/).
 ADK_AGENT_DATA_DIR=agents/roles/requirements
+
+# Diretório de saída dos agentes (workspace compartilhado).
+# Suporta caminhos absolutos, relativos (ao CWD) e com ~ (home do usuário).
+# Todos os artefatos produzidos pelos agentes são gravados aqui.
+WORKSPACE_OUTPUT_DIR=./workspace_output
+
+# Chave Google AI — necessária apenas para modelos Gemini nativos.
+GOOGLE_API_KEY=

--- a/adk/README.md
+++ b/adk/README.md
@@ -69,6 +69,40 @@ Por padrão `app/main.py` escaneia `src/agents/`. Para apontar para outro diret�
 export ADK_AGENTS_DIR=outro/caminho
 ```
 
+### Workspace de saída dos agentes
+
+Todos os artefatos produzidos pelos agentes (requisitos, design, código, relatórios, testes) são gravados em um diretório de workspace configurável via variável de ambiente:
+
+```bash
+# .env
+WORKSPACE_OUTPUT_DIR=./workspace_output   # default
+```
+
+Aceita caminhos absolutos (`/opt/ai4se/output`), relativos ao CWD (`workspace_output`), e com `~` (`~/ai4se_output`).
+
+Estrutura criada automaticamente:
+
+```text
+$WORKSPACE_OUTPUT_DIR/
+├── .ai4se_workspace          # marker de segurança (não remova)
+├── requirements/             # Time 1 — HUs, RFs, RNFs, glossário
+├── design/                   # Time 2 — análises técnicas
+│   ├── diagrams/             #   diagramas Mermaid
+│   ├── reports/              #   relatórios Markdown
+│   ├── staging/              #   staging do io_agent
+│   └── validation/           #   validações
+├── tasks/                    # Time 4 — tasks contextualizadas (JSON)
+├── coder/                    # Time 4 — código gerado
+├── review/                   # Time 4 — relatórios de revisão
+├── tests/                    # Time 3 — testes e QA
+│   ├── inputs/               #   requisitos recebidos pelo QA
+│   ├── planning/             #   planejamento de testes
+│   └── fixes/                #   correções automáticas
+└── ...
+```
+
+O workspace e limpo e recriado pelo **orchestrator** no inicio de cada fresh run. Um marker `.ai4se_workspace` e gravado na raiz para evitar que `init_workspace()` apague acidentalmente um diretorio que nao seja workspace.
+
 ## Execução com Docker
 
 Pré-requisito: **Docker** (e Docker Compose) instalados. Copie `.env.example` para `.env` e preencha.
@@ -215,7 +249,7 @@ Esperado:
 | `workspace_output/review/` | `coding_review_pipeline` | `verificacao_revisao.md` (relatório do reviewer) |
 | `workspace_output/tests/` | `qa_pipeline` | **geralmente vazio** — `action_planner` trava em HITL antes de gerar |
 
-> **Importante**: `workspace_output/` é apagado no próximo run do `coding_review_pipeline`. Antes de qualquer reexecução, copie para fora se quiser preservar:
+> **Importante**: `workspace_output/` é apagado e recriado pelo `orchestrator` no início de cada fresh run. Antes de qualquer reexecução, copie para fora se quiser preservar:
 >
 > ```bash
 > cp -r workspace_output /tmp/fotografo-app
@@ -330,7 +364,7 @@ rm -rf adk/workspace_output/   # limpa artefatos da run anterior
 rm -rf /tmp/fotografo-app      # limpa o app gerado
 ```
 
-Reinicie o uvicorn do `adk/`, reabra o Dev UI e cole o prompt de novo. O `workflow_coding_review` faz `init_workspace()` no import e recria `workspace_output/` zerado.
+Reinicie o uvicorn do `adk/`, reabra o Dev UI e cole o prompt de novo. O `orchestrator` executa `init_workspace()` no início de cada fresh run e recria `workspace_output/` zerado.
 
 ## GitHub Copilot (LiteLLM)
 

--- a/adk/shared/workspace.py
+++ b/adk/shared/workspace.py
@@ -23,6 +23,10 @@ logger = logging.getLogger(__name__)
 _ENV_WORKSPACE = "WORKSPACE_OUTPUT_DIR"
 _DEFAULT_WORKSPACE = "./workspace_output"
 
+# Arquivo marker que identifica um diretório como workspace gerenciado.
+# Previne rmtree acidental em diretórios que não são workspace.
+_WORKSPACE_MARKER = ".ai4se_workspace"
+
 # Mapeamento agente → subpasta dentro do workspace.
 # Cobre os 14 agentes individuais + 5 workflows + o orchestrator.
 # Subpastas são logicamente agrupadas por Time.
@@ -91,16 +95,51 @@ def init_workspace() -> Path:
     Deve ser chamado no início de cada nova sessão/prompt para garantir
     um ambiente limpo.
 
+    Safety checks:
+    - Se o diretório já existe, só remove se contiver o marker
+      `.ai4se_workspace` (previne rmtree acidental em diretórios errados).
+    - Valida que o diretório pode ser criado (fail-fast em caso de
+      permissões insuficientes ou path inválido).
+
     Returns:
         Path: Caminho absoluto da raiz do workspace recriado.
+
+    Raises:
+        PermissionError: Se não houver permissão para criar/limpar o diretório.
+        RuntimeError: Se o diretório existente não for um workspace gerenciado
+            (ausência do marker `.ai4se_workspace`).
     """
     root = get_workspace_root()
 
     if root.exists():
+        marker = root / _WORKSPACE_MARKER
+        if not marker.exists():
+            raise RuntimeError(
+                f"[WORKSPACE] Recusa em limpar '{root}': diretório existe mas "
+                f"não contém o marker '{_WORKSPACE_MARKER}'. "
+                f"Se este é o diretório correto, crie o marker manualmente ou "
+                f"remova o diretório antes de executar."
+            )
         shutil.rmtree(root)
         logger.info(f"[WORKSPACE] Workspace anterior removido: {root}")
 
-    root.mkdir(parents=True, exist_ok=True)
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except PermissionError as exc:
+        raise PermissionError(
+            f"[WORKSPACE] Sem permissão para criar workspace em '{root}'. "
+            f"Verifique a variável {_ENV_WORKSPACE} e as permissões do diretório."
+        ) from exc
+    except OSError as exc:
+        raise OSError(
+            f"[WORKSPACE] Falha ao criar workspace em '{root}': {exc}"
+        ) from exc
+
+    # Cria marker para identificar este diretório como workspace gerenciado.
+    (root / _WORKSPACE_MARKER).write_text(
+        "Diretório gerenciado pelo sistema AI4SE. Não remova este arquivo.\n",
+        encoding="utf-8",
+    )
 
     # Cria todas as subpastas únicas (dedup via set)
     subdirs_unicos = set(AGENT_DIRS.values())

--- a/adk/src/agents/orchestrator/agent.py
+++ b/adk/src/agents/orchestrator/agent.py
@@ -36,6 +36,8 @@ from src.agents.workflow_design_pipeline.agent import agent as design_pipeline
 from src.agents.workflow_coding_review.agent import agent as coding_review_pipeline
 from src.agents.workflow_qa.agent import agent as qa_pipeline
 
+from shared.workspace import init_workspace
+
 from src.agents.orchestrator._helpers import (
     _build_function_response_payload,
     _build_input,
@@ -194,6 +196,9 @@ class _PipelineOrchestrator(BaseAgent):
         # Fresh run reseta accumulated (nova conversa SDLC).
         state["accumulated_outputs"] = []
         accumulated: list[tuple[str, str]] = []
+
+        # Inicializa (limpa e recria) o workspace de saída dos agentes.
+        init_workspace()
 
         # Se houver _live_runner legado em outer_sid (sessão zombie), fecha.
         legacy = self._live_runners.pop(outer_sid, None)

--- a/adk/src/agents/qa_agent/tools/pytest_runner.py
+++ b/adk/src/agents/qa_agent/tools/pytest_runner.py
@@ -15,7 +15,8 @@ logger = logging.getLogger("qa_agent_tool")
 
 def _gerar_doubt_artifact_sincrono(id_artefato: str, motivo: str, caminho_base: Path) -> str:
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
-    doubt_dir = caminho_base.parent / "doubt_artifacts"
+    from shared.workspace import get_agent_workspace
+    doubt_dir = get_agent_workspace("receive_requirements") / "doubt_artifacts"
     doubt_dir.mkdir(parents=True, exist_ok=True)
 
     nome_arquivo = f"Doubt_Artifact_{id_artefato}_{timestamp}.md"

--- a/adk/src/agents/workflow_coding_review/agent.py
+++ b/adk/src/agents/workflow_coding_review/agent.py
@@ -21,7 +21,6 @@ from shared.agent_factory import _bind_tool_to_workspace
 from shared.workspace import (
     get_agent_workspace,
     get_workspace_root,
-    init_workspace,
 )
 from shared.tools import (
     tool_criar_arquivo,
@@ -38,9 +37,9 @@ from shared.tools import (
     ler_chunk,
 )
 
-# Inicializa o workspace na importação. O orchestrator cria sessões isoladas
-# por pipeline, mas todas compartilham o mesmo workspace_output em disco.
-_WORKSPACE_ROOT = str(init_workspace())
+# O workspace é inicializado pelo orchestrator no início de cada fresh run.
+# Aqui apenas resolvemos os caminhos para binding das tools.
+_WORKSPACE_ROOT = str(get_workspace_root())
 _REQ_WS = str(get_agent_workspace("requirements"))
 _CODER_WS = str(get_agent_workspace("coder"))
 _REVIEW_WS = str(get_agent_workspace("reviewer"))

--- a/adk/tests/unit/test_workspace.py
+++ b/adk/tests/unit/test_workspace.py
@@ -84,3 +84,24 @@ def test_agent_dirs_cobre_agentes_principais():
     ]
     for agente in esperados:
         assert agente in AGENT_DIRS, f"Agente {agente} ausente em AGENT_DIRS"
+
+
+def test_init_workspace_cria_marker(monkeypatch, tmp_path):
+    """init_workspace cria o marker .ai4se_workspace na raiz."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+    from shared.workspace import init_workspace, _WORKSPACE_MARKER
+    root = init_workspace()
+    marker = root / _WORKSPACE_MARKER
+    assert marker.is_file()
+    assert "AI4SE" in marker.read_text(encoding="utf-8")
+
+
+def test_init_workspace_recusa_rmtree_sem_marker(monkeypatch, tmp_path):
+    """init_workspace levanta RuntimeError se diretório existe sem marker."""
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir()
+    (ws_dir / "arquivo_qualquer.txt").write_text("dados")
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(ws_dir))
+    from shared.workspace import init_workspace
+    with pytest.raises(RuntimeError, match="não contém o marker"):
+        init_workspace()


### PR DESCRIPTION
… env var

- Declare WORKSPACE_OUTPUT_DIR in .env.example with documentation
- Move init_workspace() call from workflow_coding_review import-time to orchestrator's _handle_fresh_run (single canonical init point)
- Add .ai4se_workspace marker file to prevent accidental rmtree on non-workspace directories
- Add fail-fast validation (PermissionError/RuntimeError) in init_workspace()
- Fix pytest_runner doubt artifact path to use get_agent_workspace() instead of hardcoded relative path
- Add unit tests for marker creation and safety check
- Document workspace configuration in README

Closes #281