### PR TITLE
correcao_bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,12 @@ adk/temp/
 adk/artifacts
 
 # Workspace centralizado dos agentes (Phase 2 — workspace_output/<agente>/...)
-adk/workspace_output/
+# Mantemos apenas o marker versionado em adk/workspace_output para permitir
+# bootstrap seguro do init_workspace; o restante continua ignorado.
 workspace_output/
+!adk/workspace_output/
+adk/workspace_output/*
+!adk/workspace_output/.ai4se_workspace
 
 # Environment variables
 .env

--- a/adk/pyproject.toml
+++ b/adk/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "google-adk>=1.33.0",
+    "docker>=7.1.0",
     "litellm (>=1.72.2,<2.0.0)",
     "fastapi>=0.124.1",
     "uvicorn (>=0.35.0,<0.36.0)",

--- a/adk/src/agents/context_engineer/schemas.py
+++ b/adk/src/agents/context_engineer/schemas.py
@@ -6,7 +6,7 @@ de cada task) e Task (Context Window completo para o coder).
 Portado de feat/me2/coding_squad (Time 4).
 """
 
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
@@ -37,9 +37,12 @@ class Contract(BaseModel):
         default_factory=list,
         description="Arquivos que o Coder deve CRIAR ou MODIFICAR",
     )
-    interfaces: Optional[str] = Field(
+    interfaces: Optional[str | dict[str, Any]] = Field(
         default=None,
-        description="Assinatura de interface/contrato que deve ser respeitado",
+        description=(
+            "Assinatura de interface/contrato que deve ser respeitado. "
+            "Aceita texto livre ou objeto estruturado."
+        ),
     )
 
 

--- a/adk/tests/unit/test_context_engineer.py
+++ b/adk/tests/unit/test_context_engineer.py
@@ -50,6 +50,20 @@ def test_schemas_task_com_contract():
     assert task.contract.outputs == ["src/auth.py"]
 
 
+def test_schemas_contract_interfaces_objeto_aceito():
+    from src.agents.context_engineer.schemas import Contract
+    contract = Contract(
+        interfaces={
+            "create_ensaio": {
+                "method": "POST",
+                "params": {"titulo": "str", "cliente": "str"},
+            }
+        }
+    )
+    assert isinstance(contract.interfaces, dict)
+    assert "create_ensaio" in contract.interfaces
+
+
 def test_schemas_tasks_output_completo():
     from src.agents.context_engineer.schemas import TasksOutput, MacroContext, Task, Contract
     output = TasksOutput(

--- a/adk/uv.lock
+++ b/adk/uv.lock
@@ -9,6 +9,7 @@ source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
     { name = "boto3" },
+    { name = "docker" },
     { name = "fastapi" },
     { name = "fastembed" },
     { name = "google-adk" },
@@ -46,6 +47,7 @@ dev = [
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0,<1.0.0" },
     { name = "boto3", specifier = ">=1.40.15" },
+    { name = "docker", specifier = ">=7.1.0" },
     { name = "fastapi", specifier = ">=0.124.1" },
     { name = "fastembed", specifier = ">=0.7.1,<0.8.0" },
     { name = "google-adk", specifier = ">=1.33.0" },
@@ -525,6 +527,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
 ]
 
 [[package]]

--- a/adk/workspace_output/.ai4se_workspace
+++ b/adk/workspace_output/.ai4se_workspace
@@ -1,0 +1,1 @@
+Diretório gerenciado pelo sistema AI4SE. Não remova este arquivo.


### PR DESCRIPTION
1º erro (ModuleNotFoundError: Fail to load 'orchestrator' module. No module named 'docker')
    Motivo: o agente de code_review usa a ferramenta docker para algumas coisas.
    Solução: só adicionar "docker>=7.1.0" na lista de dependências desativar o ambiente, rodar um "uv sync" no terminal e depois ativar o ambiente novamente
2º erro (RuntimeError: [WORKSPACE] Recusa em limpar)
    Motivo: A logica de identificação e navegação do workspace precisa de um marcador para saber qual é a pasta correta.
    Solução: colocar, dentro da pasta 'workspace_output' um arquivo chamado '.ai4se_workspace' com a frase "Diretório gerenciado pelo sistema AI4SE. 
    
Além disso, também tinha outro bug do pydantic sobre o contrato do schema TasksOutputs, para resolver isso, coloquei outra opção do campo para aceitar string ou um dicionário (json), mas não sei se dá para deixar dessa forma ou se é justamente isso que temos que assegurar que aconteça (ser um tipo específico).