### PR TITLE
285 fluxo1

### DIFF
--- a/adk/shared/manifest.py
+++ b/adk/shared/manifest.py
@@ -1,0 +1,78 @@
+"""Modelo de contrato comum: Manifesto de Fase.
+
+Cada Time persiste um manifesto pequeno no `session.state` (via state_delta)
+listando apenas metadados dos artefatos. O conteúdo volumoso fica em arquivos
+no workspace (`workspace_output/sessions/<session_id>/<time>/`).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class PhaseStatus(str, Enum):
+    """Status possíveis de uma fase do SDLC."""
+
+    OK = "ok"
+    BLOCKED = "blocked"
+    PARTIAL = "partial"
+
+
+class ArtifactItem(BaseModel):
+    """Metadados de um artefato persistido no workspace."""
+
+    tipo: str
+    id: str
+    path: str
+
+
+class DoubtItem(BaseModel):
+    """Metadados de uma dúvida aberta por um Time."""
+
+    id: str
+    severidade: Literal["alta", "media", "baixa"]
+    bloqueante: bool
+    path: str
+
+
+class PhaseManifest(BaseModel):
+    """Manifesto leve emitido ao final de cada fase do SDLC.
+
+    Invariantes:
+      - status=ok  ⇒ nenhuma dúvida bloqueante.
+      - status=blocked ⇒ ao menos uma dúvida bloqueante.
+    """
+
+    phase: str
+    status: PhaseStatus
+    artifacts: list[ArtifactItem] = Field(default_factory=list)
+    doubts: list[DoubtItem] = Field(default_factory=list)
+    summary: str = ""
+
+    @field_validator("summary")
+    @classmethod
+    def _limitar_summary(cls, valor: str) -> str:
+        """summary deve ser curto (≤ 500 tokens ~ 4000 chars de segurança)."""
+        if len(valor) > 4000:
+            raise ValueError("summary excede o limite de ~500 tokens")
+        return valor
+
+    @model_validator(mode="after")
+    def _checar_invariantes(self) -> PhaseManifest:
+        tem_bloqueante = any(d.bloqueante for d in self.doubts)
+        if self.status == PhaseStatus.OK and tem_bloqueante:
+            raise ValueError(
+                "status=ok não permite dúvidas bloqueantes"
+            )
+        if self.status == PhaseStatus.BLOCKED and not tem_bloqueante:
+            raise ValueError(
+                "status=blocked exige ao menos uma dúvida bloqueante"
+            )
+        return self
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        """Serialização compatível com state_delta do ADK."""
+        return super().model_dump(**kwargs)

--- a/adk/src/agents/orchestrator/_helpers.py
+++ b/adk/src/agents/orchestrator/_helpers.py
@@ -8,6 +8,8 @@ de state, inspeção de event shape).
 from datetime import datetime, timezone
 from typing import Any
 
+from shared.manifest import PhaseManifest
+
 
 EMPTY_RETRY_PROMPT = (
     "Sua resposta anterior veio vazia. Por favor, reprocesse o pedido. "
@@ -174,3 +176,72 @@ def _build_function_response_payload(
             .strftime("%Y-%m-%dT%H:%M:%SZ"),
         "checkpoint_id": checkpoint_id,
     }
+
+
+def _load_phase_manifests(state: dict[str, Any]) -> list[PhaseManifest]:
+    """Carrega e valida os manifestos de fase presentes no state."""
+    raw = state.get("phase_manifests", []) or []
+    return [PhaseManifest.model_validate(item) for item in raw]
+
+
+def _build_manifest_input(manifests: list[PhaseManifest]) -> str:
+    """Monta input leve com a lista de manifestos para o próximo pipeline.
+
+    O orquestrador dispatcher fino NUNCA abre os artefatos nem cola seu
+    conteúdo. Apenas repassa os metadados (phase, status, paths).
+    """
+    if not manifests:
+        return ""
+
+    linhas = ["Manifesto de Fase das fases anteriores:"]
+    for manifest in manifests:
+        linhas.append(f"\n## phase: {manifest.phase} (status: {manifest.status.value})")
+        if manifest.summary:
+            linhas.append(f"summary: {manifest.summary}")
+        if manifest.artifacts:
+            linhas.append("artifacts:")
+            for artefato in manifest.artifacts:
+                linhas.append(
+                    f"  - tipo={artefato.tipo} id={artefato.id} path={artefato.path}"
+                )
+        if manifest.doubts:
+            linhas.append("doubts:")
+            for duvida in manifest.doubts:
+                linhas.append(
+                    f"  - id={duvida.id} severidade={duvida.severidade} "
+                    f"bloqueante={duvida.bloqueante} path={duvida.path}"
+                )
+    return "\n".join(linhas)
+
+
+def _merge_state_delta(state: dict[str, Any], delta: dict[str, Any] | None) -> None:
+    """Aplica um state_delta vindo de um pipeline interno no state externo.
+
+    Faz merge de listas (como phase_manifests) concatenando novos itens.
+    """
+    if not delta:
+        return
+    for key, value in delta.items():
+        if key == "phase_manifests" and isinstance(value, list):
+            existing = state.get("phase_manifests", [])
+            if not isinstance(existing, list):
+                existing = []
+            # Evita duplicatas baseadas em (phase, ids dos artefatos).
+            existing_keys = {
+                (
+                    m.get("phase"),
+                    tuple(sorted(a.get("id") for a in m.get("artifacts", []))),
+                )
+                for m in existing
+            }
+            for item in value:
+                item_key = (
+                    item.get("phase"),
+                    tuple(sorted(a.get("id") for a in item.get("artifacts", []))),
+                )
+                if item_key not in existing_keys:
+                    existing.append(item)
+                    existing_keys.add(item_key)
+            state["phase_manifests"] = existing
+        else:
+            state[key] = value

--- a/adk/src/agents/orchestrator/agent.py
+++ b/adk/src/agents/orchestrator/agent.py
@@ -41,10 +41,13 @@ from shared.workspace import init_workspace
 from src.agents.orchestrator._helpers import (
     _build_function_response_payload,
     _build_input,
+    _build_manifest_input,
     _clear_pause_state,
     _extract_user_text,
     _is_empty_response,
     _is_pending_long_running_call,
+    _load_phase_manifests,
+    _merge_state_delta,
     _parse_decision,
     _set_pause_state,
     EMPTY_RETRY_PROMPT,
@@ -197,6 +200,9 @@ class _PipelineOrchestrator(BaseAgent):
         state["accumulated_outputs"] = []
         accumulated: list[tuple[str, str]] = []
 
+        # Manifestos das fases anteriores — contrato leve entre Times.
+        phase_manifests = _load_phase_manifests(state)
+
         # Inicializa (limpa e recria) o workspace de saída dos agentes.
         init_workspace()
 
@@ -205,8 +211,20 @@ class _PipelineOrchestrator(BaseAgent):
         if legacy is not None:
             await legacy[0].close()
 
-        for pipeline in self._pipelines:
-            pipeline_input = _build_input(user_text, accumulated)
+        for idx, pipeline in enumerate(self._pipelines):
+            # Dispatcher fino: repassa só os manifestos das fases anteriores.
+            prior_manifests = phase_manifests[:idx]
+            manifest_context = _build_manifest_input(prior_manifests)
+            if manifest_context:
+                pipeline_input = (
+                    f"{user_text}\n\n"
+                    f"---\n"
+                    f"{manifest_context}\n"
+                    f"---"
+                )
+            else:
+                pipeline_input = user_text
+
             content = types.Content(
                 role="user",
                 parts=[types.Part.from_text(text=pipeline_input)],
@@ -221,8 +239,12 @@ class _PipelineOrchestrator(BaseAgent):
                 credential_service=ctx.credential_service,
                 plugins=ctx.plugin_manager.plugins if ctx.plugin_manager else None,
             )
+            # Repassa os manifestos acumulados para o pipeline ler paths do workspace.
+            inner_state = {
+                "phase_manifests": [m.model_dump() for m in prior_manifests]
+            }
             inner_session = await runner.session_service.create_session(
-                app_name=pipeline.name, user_id=ctx.user_id, state={},
+                app_name=pipeline.name, user_id=ctx.user_id, state=inner_state,
             )
 
             last_text = ""
@@ -233,6 +255,9 @@ class _PipelineOrchestrator(BaseAgent):
                 new_message=content,
             ):
                 yield event
+                # Aplica state_delta vindo do pipeline (ex: novo manifesto QA).
+                if event.actions and event.actions.state_delta:
+                    _merge_state_delta(state, event.actions.state_delta)
                 if event.content and event.content.parts:
                     for part in event.content.parts:
                         if part.text:
@@ -283,11 +308,14 @@ class _PipelineOrchestrator(BaseAgent):
                     "paused_inner_session_id": state["paused_inner_session_id"],
                     "paused_function_call": state["paused_function_call"],
                     "accumulated_outputs": accumulated,
+                    "phase_manifests": state.get("phase_manifests", []),
                 })
                 return  # NÃO roda pipelines subsequentes
 
             # Pipeline concluiu sem pausa.
             accumulated.append((pipeline.name, last_text))
+            # Atualiza manifestos locais para a próxima iteração.
+            phase_manifests = _load_phase_manifests(state)
             await runner.close()
 
         state["accumulated_outputs"] = accumulated
@@ -296,6 +324,7 @@ class _PipelineOrchestrator(BaseAgent):
             "paused_pipeline": None,
             "paused_inner_session_id": None,
             "paused_function_call": None,
+            "phase_manifests": state.get("phase_manifests", []),
         })
 
     @staticmethod

--- a/adk/src/agents/workflow_qa/agent.py
+++ b/adk/src/agents/workflow_qa/agent.py
@@ -20,6 +20,67 @@ from src.agents.workflow_qa.tools.planner_wrapper import invocar_planejamento_qa
 
 _DEFAULT_MODEL = "gemini-2.5-flash"
 
+
+def _emit_qa_manifest(callback_context) -> "EventActions":
+    """Callback executado ao final do workflow_qa.
+
+    Varre o workspace de testes e emite o Manifesto de Fase `qa` no
+    session.state. O conteúdo dos artefatos permanece nos arquivos;
+    só os metadados trafegam no state.
+    """
+    from google.adk.events.event_actions import EventActions
+
+    from shared.manifest import ArtifactItem, PhaseManifest, PhaseStatus
+    from shared.workspace import get_workspace_root
+
+    root = get_workspace_root()
+    artifacts: list[ArtifactItem] = []
+
+    # JSONs de input em tests/inputs/<slug>.json
+    inputs_dir = root / "tests" / "inputs"
+    if inputs_dir.exists():
+        for path in sorted(inputs_dir.iterdir()):
+            if path.is_file() and path.suffix == ".json":
+                artifacts.append(
+                    ArtifactItem(
+                        tipo="input",
+                        id=path.stem,
+                        path=str(path.relative_to(root)),
+                    )
+                )
+
+    # Código de teste em tests/<slug>/test_<slug>.py
+    tests_dir = root / "tests"
+    if tests_dir.exists():
+        for slug_dir in sorted(tests_dir.iterdir()):
+            if not slug_dir.is_dir() or slug_dir.name == "inputs":
+                continue
+            test_file = slug_dir / f"test_{slug_dir.name}.py"
+            if test_file.exists():
+                artifacts.append(
+                    ArtifactItem(
+                        tipo="teste",
+                        id=slug_dir.name,
+                        path=str(test_file.relative_to(root)),
+                    )
+                )
+
+    status = PhaseStatus.OK if artifacts else PhaseStatus.PARTIAL
+
+    manifest = PhaseManifest(
+        phase="qa",
+        status=status,
+        artifacts=artifacts,
+        doubts=[],
+        summary=f"QA gerou {len(artifacts)} artefato(s) de teste.",
+    )
+
+    state = callback_context.state
+    manifests = list(state.get("phase_manifests", []) or [])
+    manifests.append(manifest.model_dump())
+
+    return EventActions(state_delta={"phase_manifests": manifests})
+
 _INSTRUCTION = """
 Você é o pipeline de QA / Testes do Time 3.
 
@@ -116,4 +177,5 @@ agent = LlmAgent(
         FunctionTool(DoubtArtifactGenerator.generate),
         LongRunningFunctionTool(aguardar_aprovacao_humana),
     ],
+    after_agent_callback=_emit_qa_manifest,
 )

--- a/adk/tests/integration/test_integration_orchestrator_qa.py
+++ b/adk/tests/integration/test_integration_orchestrator_qa.py
@@ -1,0 +1,442 @@
+"""Integração Orquestrador → QA Agent (FRENTE 1, Cenário 1).
+
+TDD rigoroso: Red-Green-Refactor.
+
+Objetivo: garantir que o orquestrador atue como dispatcher fino,
+repassando apenas o Manifesto de Fase do coding ao QA Agent e
+exigindo de volta o manifesto de QA com os artefatos persistidos.
+"""
+
+from pathlib import Path
+from typing import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from google.adk.events.event import Event
+from google.adk.events.event_actions import EventActions
+from google.genai import types
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# FIXTURES
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_workspace(tmp_path: Path, monkeypatch) -> Path:
+    """Workspace isolado por teste, substituindo workspace_output."""
+    ws = tmp_path / "workspace_output"
+    ws.mkdir(parents=True, exist_ok=True)
+    (ws / ".ai4se_workspace").write_text("marker", encoding="utf-8")
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(ws))
+    # Garante que get_workspace_root resolva dentro do tmp_path sem
+    # poluir o default global para outros testes.
+    from shared import workspace as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "_DEFAULT_WORKSPACE", str(ws))
+    return ws
+
+
+@pytest.fixture
+def coding_manifest(tmp_workspace: Path) -> dict:
+    """Manifesto de coding mínimo com um artefato de código no workspace."""
+    coder_dir = tmp_workspace / "coder" / "src"
+    coder_dir.mkdir(parents=True, exist_ok=True)
+    code_file = coder_dir / "calculadora.py"
+    code_file.write_text(
+        "def somar(a, b):\n    return a + b\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "phase": "coding",
+        "status": "ok",
+        "artifacts": [
+            {
+                "tipo": "codigo",
+                "id": "calculadora",
+                "path": str(code_file.relative_to(tmp_workspace)),
+            }
+        ],
+        "doubts": [],
+        "summary": "Código da calculadora entregue.",
+    }
+
+
+@pytest.fixture
+def requirements_manifest(tmp_workspace: Path) -> dict:
+    """Manifesto de requirements opcional para contexto adicional."""
+    req_dir = tmp_workspace / "requirements" / "HUs"
+    req_dir.mkdir(parents=True, exist_ok=True)
+    hu_file = req_dir / "HU-001.md"
+    hu_file.write_text(
+        "# HU-001\n\nComo usuário, quero somar dois números.",
+        encoding="utf-8",
+    )
+
+    return {
+        "phase": "requirements",
+        "status": "ok",
+        "artifacts": [
+            {
+                "tipo": "HU",
+                "id": "HU-001",
+                "path": str(hu_file.relative_to(tmp_workspace)),
+            }
+        ],
+        "doubts": [],
+        "summary": "Requisito da calculadora.",
+    }
+
+
+class _FakeSession:
+    def __init__(self, session_id: str = "inner-sid", user_id: str = "u",
+                 state: dict | None = None):
+        self.id = session_id
+        self.user_id = user_id
+        self.state = state if state is not None else {}
+
+
+class _FakeSessionService:
+    def __init__(self, inner_state: dict):
+        self._state = inner_state
+
+    async def create_session(self, *, app_name, user_id, state):
+        # Mescla state inicial com o que o orchestrator passou
+        merged = dict(self._state)
+        merged.update(state)
+        self._state = merged
+        return _FakeSession(state=merged)
+
+
+class _FakeQAPipeline:
+    """Simula o workflow_qa: lê manifestos do state, gera artefatos fake
+    e devolve o manifesto de QA via state_delta no último evento.
+    """
+
+    name = "qa_pipeline"
+
+    def __init__(self, tmp_workspace: Path, inner_state: dict):
+        self.tmp_workspace = tmp_workspace
+        self.inner_state = inner_state
+        self.close = AsyncMock(return_value=None)
+
+    async def run_async(self, **kwargs) -> AsyncGenerator[Event, None]:
+        new_message = kwargs.get("new_message")
+        assert new_message is not None
+
+        # O input enviado pelo orquestrador DEVE ser a representação leve
+        # dos manifestos (não o conteúdo dos artefatos).
+        input_text = ""
+        if new_message and new_message.parts:
+            for part in new_message.parts:
+                if part.text:
+                    input_text = part.text
+                    break
+
+        assert "Manifesto de Fase" in input_text or "manifesto" in input_text.lower(), (
+            f"Orquestrador não enviou a lista de manifestos ao QA. Input: {input_text[:200]}"
+        )
+
+        # O state interno deve conter os manifestos das fases anteriores.
+        phase_manifests = self.inner_state.get("phase_manifests", [])
+        assert len(phase_manifests) >= 1, "QA não recebeu manifestos no state"
+        assert any(m["phase"] == "coding" for m in phase_manifests), (
+            "Manifesto de coding ausente"
+        )
+
+        # Gera artefatos fake de QA no workspace.
+        slug = "calculadora"
+        tests_dir = self.tmp_workspace / "tests" / slug
+        tests_dir.mkdir(parents=True, exist_ok=True)
+        test_file = tests_dir / f"test_{slug}.py"
+        test_file.write_text(
+            "def test_somar():\n    from src.calculadora import somar\n    assert somar(2, 3) == 5\n",
+            encoding="utf-8",
+        )
+
+        inputs_dir = self.tmp_workspace / "tests" / "inputs"
+        inputs_dir.mkdir(parents=True, exist_ok=True)
+        input_file = inputs_dir / f"{slug}.json"
+        input_file.write_text(
+            '{"id_artefato": "HU-001", "tipo": "HU"}',
+            encoding="utf-8",
+        )
+
+        # Emite manifesto de QA via state_delta.
+        qa_manifest = {
+            "phase": "qa",
+            "status": "ok",
+            "artifacts": [
+                {
+                    "tipo": "input",
+                    "id": slug,
+                    "path": str(input_file.relative_to(self.tmp_workspace)),
+                },
+                {
+                    "tipo": "teste",
+                    "id": slug,
+                    "path": str(test_file.relative_to(self.tmp_workspace)),
+                },
+            ],
+            "doubts": [],
+            "summary": "Testes gerados e executados com sucesso.",
+        }
+
+        updated_manifests = list(phase_manifests) + [qa_manifest]
+        self.inner_state["phase_manifests"] = updated_manifests
+
+        yield Event(
+            author="qa_pipeline",
+            invocation_id="inv-qa",
+            content=types.Content(
+                role="model",
+                parts=[types.Part(text="QA concluído com sucesso.")],
+            ),
+            actions=EventActions(
+                state_delta={"phase_manifests": updated_manifests},
+            ),
+        )
+
+
+class _FakeCtx:
+    def __init__(self, user_text: str, session_id: str = "outer-sid",
+                 state: dict | None = None):
+        self.user_content = types.Content(
+            role="user", parts=[types.Part(text=user_text)]
+        )
+        self.user_id = "test-user"
+        self.session = MagicMock()
+        self.session.id = session_id
+        self.session.state = state if state is not None else {}
+        self.artifact_service = MagicMock()
+        self.credential_service = MagicMock()
+        self.plugin_manager = MagicMock()
+        self.plugin_manager.plugins = []
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 1. FASE RED — teste de integração que falha até a implementação existir
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_envia_manifesto_ao_qa_e_recebe_manifesto_qa(
+    tmp_workspace: Path,
+    coding_manifest: dict,
+    requirements_manifest: dict,
+    monkeypatch,
+):
+    """RED/GREEN: dispatcher fino repassa manifestos e exige manifesto qa."""
+    from src.agents.orchestrator.agent import _PipelineOrchestrator
+    from shared.manifest import PhaseManifest, PhaseStatus
+
+    inner_state = {
+        "phase_manifests": [requirements_manifest, coding_manifest],
+    }
+    fake_qa = _FakeQAPipeline(tmp_workspace, inner_state)
+    fake_qa.session_service = _FakeSessionService(inner_state)
+
+    # Substitui o workflow_qa real pelo stub.
+    monkeypatch.setattr(
+        "src.agents.orchestrator.agent.qa_pipeline",
+        fake_qa,
+    )
+
+    # O Runner do orchestrator deve criar o fake QA com o state correto.
+    def _fake_runner_constructor(*, app_name, agent, **kwargs):
+        # Só intercepta o qa_pipeline; os demais pipelines usam um runner fake vazio.
+        if getattr(agent, "name", None) == "qa_pipeline":
+            return fake_qa
+        # Pipelines anteriores simulam sucesso sem eventos relevantes.
+        r = MagicMock()
+        r.session_service = _FakeSessionService({})
+        r.close = AsyncMock(return_value=None)
+        async def _empty(**kw):
+            if False:
+                yield None
+        r.run_async = _empty
+        return r
+
+    monkeypatch.setattr(
+        "src.agents.orchestrator.agent.Runner",
+        _fake_runner_constructor,
+    )
+
+    orch = _PipelineOrchestrator(name="orchestrator", description="test")
+    # Simula o SDLC completo: os 3 primeiros pipelines são stubs que já
+    # rodaram e deixaram os manifestos no state; o QA é o quarto pipeline.
+    class _StubPipeline:
+        name = "stub_pipeline"
+
+    monkeypatch.setattr(
+        _PipelineOrchestrator,
+        "_pipelines",
+        [_StubPipeline(), _StubPipeline(), _StubPipeline(), fake_qa],
+    )
+
+    ctx = _FakeCtx(
+        "Gerar testes para a calculadora",
+        session_id="outer-1",
+        state={"phase_manifests": [requirements_manifest, coding_manifest]},
+    )
+
+    events = [e async for e in orch._run_async_impl(ctx)]
+
+    # O state externo deve conter os manifestos + o manifesto de QA.
+    final_manifests = ctx.session.state.get("phase_manifests", [])
+    assert len(final_manifests) == 3, (
+        f"Esperado 3 manifestos, obtido {len(final_manifests)}"
+    )
+
+    qa_manifest_dict = final_manifests[-1]
+    qa_manifest = PhaseManifest.model_validate(qa_manifest_dict)
+
+    assert qa_manifest.phase == "qa"
+    assert qa_manifest.status == PhaseStatus.OK
+    assert len(qa_manifest.artifacts) == 2
+    assert any(a.tipo == "input" for a in qa_manifest.artifacts)
+    assert any(a.tipo == "teste" for a in qa_manifest.artifacts)
+
+    # Invariante: status ok => nenhuma dúvida bloqueante.
+    assert not any(d.bloqueante for d in qa_manifest.doubts)
+
+    # O orquestrador não deve ter lido o conteúdo dos artefatos (dispatcher fino).
+    # Se o input continha o código fonte completo, o teste fake levantaria.
+    texts = [
+        p.text
+        for e in events if e.content
+        for p in e.content.parts if p.text
+    ]
+    assert any("QA concluído" in t for t in texts)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 2. FASE GREEN — validação do manifesto construído pelo orquestrador
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_build_manifest_input_e_leve_e_nao_inclui_conteudo(tmp_workspace: Path,
+                                                            coding_manifest: dict):
+    """O input para o QA deve listar manifestos, nunca o conteúdo dos artefatos."""
+    from src.agents.orchestrator._helpers import _build_manifest_input
+    from shared.manifest import PhaseManifest
+
+    manifest = PhaseManifest.model_validate(coding_manifest)
+    text = _build_manifest_input([manifest])
+
+    assert manifest.phase in text
+    assert manifest.artifacts[0].path in text
+    assert "def somar" not in text
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 3. FASE REFACTOR — contrato forte via Pydantic
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_manifest_status_ok_proibe_duvida_bloqueante():
+    """Invariante crítica: status=ok ⇒ sem dúvidas bloqueantes."""
+    from shared.manifest import PhaseManifest, PhaseStatus, DoubtItem
+
+    with pytest.raises(ValueError, match="bloqueante"):
+        PhaseManifest(
+            phase="qa",
+            status=PhaseStatus.OK,
+            artifacts=[],
+            doubts=[
+                DoubtItem(
+                    id="D-001",
+                    severidade="alta",
+                    bloqueante=True,
+                    path="doubts/D-001.md",
+                )
+            ],
+            summary="deve falhar",
+        )
+
+
+def test_manifest_status_blocked_exige_duvida_bloqueante():
+    """status=blocked implica ao menos uma dúvida bloqueante."""
+    from shared.manifest import PhaseManifest, PhaseStatus, DoubtItem
+
+    with pytest.raises(ValueError, match="bloqueante"):
+        PhaseManifest(
+            phase="qa",
+            status=PhaseStatus.BLOCKED,
+            artifacts=[],
+            doubts=[],
+            summary="deve falhar",
+        )
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_e_roteador_puro_sem_open_em_arquivos(
+    tmp_workspace: Path,
+    coding_manifest: dict,
+    monkeypatch,
+):
+    """REFACTOR: orquestrador não abre artefatos — só roteia manifestos."""
+    from src.agents.orchestrator.agent import _PipelineOrchestrator
+
+    inner_state = {"phase_manifests": [coding_manifest]}
+    fake_qa = _FakeQAPipeline(tmp_workspace, inner_state)
+    fake_qa.session_service = _FakeSessionService(inner_state)
+    monkeypatch.setattr(
+        "src.agents.orchestrator.agent.qa_pipeline",
+        fake_qa,
+    )
+
+    def _fake_runner_constructor(*, app_name, agent, **kwargs):
+        if getattr(agent, "name", None) == "qa_pipeline":
+            return fake_qa
+        r = MagicMock()
+        r.session_service = _FakeSessionService({})
+        r.close = AsyncMock(return_value=None)
+        async def _empty(**kw):
+            if False:
+                yield None
+        r.run_async = _empty
+        return r
+
+    monkeypatch.setattr(
+        "src.agents.orchestrator.agent.Runner",
+        _fake_runner_constructor,
+    )
+
+    class _StubPipeline:
+        name = "stub_pipeline"
+
+    orch = _PipelineOrchestrator(name="orchestrator", description="test")
+    monkeypatch.setattr(
+        _PipelineOrchestrator,
+        "_pipelines",
+        [_StubPipeline(), fake_qa],
+    )
+
+    ctx = _FakeCtx(
+        "prompt",
+        session_id="outer-2",
+        state={"phase_manifests": [coding_manifest]},
+    )
+
+    open_spy = MagicMock(side_effect=open)
+    monkeypatch.setattr("builtins.open", open_spy)
+
+    _ = [e async for e in orch._run_async_impl(ctx)]
+
+    # O orquestrador não deve abrir nenhum arquivo (o QA sim, mas não o dispatcher).
+    # Filtra apenas chamadas de leitura/escrita de arquivo real (não StringIO/mocks).
+    file_opens = [
+        call for call in open_spy.call_args_list
+        if call.args and isinstance(call.args[0], (str, Path))
+    ]
+    assert len(file_opens) == 0, (
+        f"Orquestrador abriu arquivos: {[c.args[0] for c in file_opens]}"
+    )
+
+    # Garante que o manifesto final é um PhaseManifest válido.
+    from shared.manifest import PhaseManifest
+    final_manifests = ctx.session.state.get("phase_manifests", [])
+    assert len(final_manifests) == 2
+    PhaseManifest.model_validate(final_manifests[-1])


### PR DESCRIPTION
# FRENTE 1: Integração Orquestrador → QA Agent

## 1. Contexto

Este documento descreve a implementação da **FRENTE 1: Integração Orquestrador → QA Agent**, focada no **Cenário 1 — Comunicação bem-sucedida**, conforme especificado em `PR.md` e alinhada à refatoração maior documentada em `TIME_3_TESTES.md`.

A refatoração tem como objetivo transformar o `orchestrator` do AI4ES em um **dispatcher fino**: ele deve apenas rotear e sequenciar as fases do SDLC, sem executar lógica de negócio nem transformar dados pesados. Em especial, o orquestrador **não deve mais colar o conteúdo de artefatos** (código, requisitos, diagramas) nos prompts entre fases.

A solução adota o padrão recomendado pelo Google ADK:

- **Artefatos volumosos** ficam em arquivos no workspace (`workspace_output/...`).
- **Manifestos leves** trafegam no `session.state`, listando apenas metadados dos artefatos (`phase`, `status`, `artifacts[].path`, `doubts[]`, `summary`).

---

## 2. Objetivo desta Frente

Garantir que:

1. O orquestrador receba o manifesto da fase anterior (`coding`) e o repasse ao QA Agent.
2. O QA Agent leia os artefatos de código a partir dos `path` do manifesto (não a partir de texto colado).
3. O QA Agent emita seu próprio manifesto (`phase: "qa"`) com `status=ok`, lista de artefatos (`input`/`teste`), `summary` e `doubts`.
4. O orquestrador atue como roteador puro: sem abrir arquivos, sem validar conteúdo, sem retry de lógica de negócio.

---

## 3. O Manifesto de Fase

O contrato comum entre todas as fases do SDLC é o **Manifesto de Fase**. Ele é pequeno o suficiente para ir no `session.state`, mas descritivo o suficiente para que a próxima fase saiba o que foi produzido e onde ler os detalhes.

```json
{
  "phase": "requirements | design | coding | qa",
  "status": "ok | blocked | partial",
  "artifacts": [
    {"tipo": "codigo", "id": "calculadora", "path": "coder/src/calculadora.py"}
  ],
  "doubts": [
    {"id": "D-001", "severidade": "alta", "bloqueante": true, "path": "requirements/doubts/D-001.md"}
  ],
  "summary": "Resumo curto (≤ 500 tokens) do que a fase produziu"
}
```

### Invariantes

- `status = "ok"` ⇒ nenhum item em `doubts` pode ter `bloqueante = true`.
- `status = "blocked"` ⇒ deve haver ao menos uma dúvida com `bloqueante = true`.

Essas invariantes são validadas automaticamente pelo modelo Pydantic.

---

## 4. Arquivos Criados e Modificados

### 4.1 `adk/shared/manifest.py` (NOVO)

Modelo Pydantic v2 do Manifesto de Fase. Define:

- `PhaseStatus` — enum com `OK`, `BLOCKED`, `PARTIAL`.
- `ArtifactItem` — metadados de um artefato (`tipo`, `id`, `path`).
- `DoubtItem` — metadados de uma dúvida (`id`, `severidade`, `bloqueante`, `path`).
- `PhaseManifest` — manifesto completo com validadores de invariante.

A validação ocorre em dois níveis:

1. `field_validator("summary")` — limita o tamanho do resumo.
2. `model_validator(mode="after")` — garante as invariantes de `status` vs. `doubts`.

Exemplo de uso:

```python
from shared.manifest import PhaseManifest, PhaseStatus

manifest = PhaseManifest(
    phase="qa",
    status=PhaseStatus.OK,
    artifacts=[...],
    doubts=[],
    summary="Testes gerados com sucesso.",
)
state_delta = {"phase_manifests": [manifest.model_dump()]}
```

### 4.2 `adk/src/agents/orchestrator/_helpers.py`

Adicionadas três funções puras para dar suporte ao dispatcher fino:

#### `_load_phase_manifests(state)`

Carrega e valida a lista de manifestos presentes no `session.state`.

```python
phase_manifests = _load_phase_manifests(state)
# Retorna list[PhaseManifest]
```

#### `_build_manifest_input(manifests)`

Monta o texto leve que o orquestrador anexa ao prompt do próximo pipeline. **Nunca inclui o conteúdo dos artefatos** — apenas `phase`, `status`, `summary`, `artifacts[].tipo/id/path` e `doubts[].id/severidade/bloqueante/path`.

```python
manifest_context = _build_manifest_input(prior_manifests)
```

#### `_merge_state_delta(state, delta)`

Aplica um `state_delta` vindo de um pipeline interno no state externo do orquestrador. Para `phase_manifests`, faz merge concatenando novos manifestos e evitando duplicatas com base em `(phase, ids dos artefatos)`.

```python
_merge_state_delta(state, event.actions.state_delta)
```

### 4.3 `adk/src/agents/orchestrator/agent.py`

O `_PipelineOrchestrator` foi ajustado para operar no novo contrato:

1. **No início do `_handle_fresh_run`**, carrega os manifestos já existentes no state:
   ```python
   phase_manifests = _load_phase_manifests(state)
   ```

2. **Para cada pipeline**, constrói o input combinando:
   - O prompt original do usuário.
   - O contexto leve dos manifestos das fases anteriores (`_build_manifest_input`).

3. **Cria a sessão interna** repassando os manifestos acumulados:
   ```python
   inner_state = {"phase_manifests": [m.model_dump() for m in prior_manifests]}
   inner_session = await runner.session_service.create_session(
       app_name=pipeline.name, user_id=ctx.user_id, state=inner_state,
   )
   ```

4. **Aplica `state_delta`** dos eventos emitidos pelo pipeline no state externo:
   ```python
   if event.actions and event.actions.state_delta:
       _merge_state_delta(state, event.actions.state_delta)
   ```

5. **Persiste `phase_manifests`** no state final, ao lado do legado `accumulated_outputs`.

O orquestrador **não abre arquivos**, **não lê código** e **não decide se o teste passou**. Ele apenas roteia e persiste os manifestos.

### 4.4 `adk/src/agents/workflow_qa/agent.py`

Adicionado o callback `after_agent_callback=_emit_qa_manifest` ao `LlmAgent` do `qa_pipeline`.

#### `_emit_qa_manifest(callback_context)`

Função chamada automaticamente ao final da execução do workflow_qa. Ela:

1. Varre o workspace de testes:
   - `workspace_output/tests/inputs/<slug>.json` → artefato do tipo `input`.
   - `workspace_output/tests/<slug>/test_<slug>.py` → artefato do tipo `teste`.

2. Constrói um `PhaseManifest` com:
   - `phase="qa"`
   - `status=ok` se encontrou artefatos; `partial` caso contrário.
   - `artifacts` com `tipo`, `id` e `path` relativos à raiz do workspace.
   - `doubts=[]` (cenário 1 — comunicação bem-sucedida).
   - `summary` curto.

3. Atualiza a chave `phase_manifests` no state e retorna um `EventActions`:
   ```python
   return EventActions(state_delta={"phase_manifests": manifests})
   ```

Esse callback garante que o próprio Time 3 seja responsável por declarar o que produziu, sem depender do orquestrador.

### 4.5 `adk/tests/integration/test_integration_orchestrator_qa.py` (NOVO)

Suite de testes de integração estruturada nas três fases do TDD.

#### Fase RED — `test_orchestrator_envia_manifesto_ao_qa_e_recebe_manifesto_qa`

Teste de integração que simula o fluxo completo:

- Cria workspace com código em `coder/`.
- Prepara manifestos de `requirements` e `coding` no `session.state`.
- Substitui o `workflow_qa` por um stub que valida:
  - Recebeu os manifestos no state interno.
  - O input contém a lista de manifestos (não o conteúdo dos artefatos).
  - Devolve um manifesto `qa` via `state_delta`.
- Verifica que o state final do orquestrador contém 3 manifestos, sendo o último um `PhaseManifest` válido de QA com `status=ok`.

#### Fase GREEN — `test_build_manifest_input_e_leve_e_nao_inclui_conteudo`

Valida que `_build_manifest_input` produz um texto leve com metadados e **não inclui o conteúdo do arquivo** (`def somar` não aparece no input).

#### Fase REFACTOR — testes do contrato Pydantic

- `test_manifest_status_ok_proibe_duvida_bloqueante`: garante a invariante crítica.
- `test_manifest_status_blocked_exige_duvida_bloqueante`: garante a contrapartida.
- `test_orchestrator_e_roteador_puro_sem_open_em_arquivos`: verifica que o orquestrador não chama `open()` durante a execução, confirmando o papel de dispatcher puro.

---

## 5. Fluxo de Dados

```text
┌─────────────────┐     state.phase_manifests       ┌─────────────────────┐
│   Orquestrador  │ ───────────────────────────────▶│   QA Agent          │
│  (dispatcher)   │                                   │  (workflow_qa)      │
│                 │◀── EventActions.state_delta ─────│                     │
└─────────────────┘      phase_manifests + qa        └─────────────────────┘
         │                                                    │
         │  1. lê manifesto coding                            │  2. lê código de
         │     (apenas metadados)                             │     workspace_output/coder/
         │                                                    │
         │  3. repassa prior_manifests                        │  4. gera testes em
         │     no state + input leve                          │     workspace_output/tests/
         │                                                    │
         │◀───────────────────────────────────────────────────│  5. emite manifesto qa
         │       state_delta com phase_manifests atualizado    │     via after_agent_callback
```

---

## 6. Estratégia e Evidências de Testes

Todos os testes foram executados no ambiente virtual do projeto (`adk/.venv`) com Python 3.14.4, pytest 9.0.3 e o interpretador correto (`.venv\Scripts\python.exe`). Inicialmente houve um erro de ambiente (`ModuleNotFoundError: No module named 'docker'`), que foi resolvido instalando `docker==7.2.0` via `uv pip install` — nenhuma alteração de código foi necessária.

### 6.1. Abordagem TDD

A implementação seguiu o ciclo **Red-Green-Refactor**:

1. **RED**: escreveu-se `test_integration_orchestrator_qa.py` importando `PhaseManifest`, `_build_manifest_input` e simulando o runner do QA. A primeira execução falhou porque os módulos ainda não existiam.
2. **GREEN**: implementou-se o mínimo necessário (`shared/manifest.py`, helpers no orquestrador, callback no workflow_qa) para fazer os testes passarem.
3. **REFACTOR**: extraiu-se o modelo Pydantic v2, garantiu-se que o orquestrador não abre arquivos e adicionaram-se testes de contrato e de dispatcher puro.

### 6.2. Suite criada: `test_integration_orchestrator_qa.py`

| Teste | Fase TDD | O que valida |
|---|---|---|
| `test_orchestrator_envia_manifesto_ao_qa_e_recebe_manifesto_qa` | RED/GREEN | Fluxo end-to-end: orquestrador recebe manifestos de `requirements` e `coding`, repassa ao QA (via state + input leve), recebe de volta o manifesto `qa` com `status=ok` e artefatos `input`/`teste` nos caminhos corretos. |
| `test_build_manifest_input_e_leve_e_nao_inclui_conteudo` | GREEN | `_build_manifest_input` lista os manifestos e nunca cola o conteúdo dos artefatos (ex.: `def somar` não aparece no input). |
| `test_manifest_status_ok_proibe_duvida_bloqueante` | REFACTOR | Invariante crítica: `status=ok` rejeita qualquer dúvida com `bloqueante=true`. |
| `test_manifest_status_blocked_exige_duvida_bloqueante` | REFACTOR | `status=blocked` só é válido se houver ao menos uma dúvida bloqueante. |
| `test_orchestrator_e_roteador_puro_sem_open_em_arquivos` | REFACTOR | O orquestrador não chama `open()` durante a execução — confirma o papel de dispatcher puro. |

#### Estratégia de mock

Para não depender de LLM real, o teste de integração usa:

- `tmp_workspace` (fixture): workspace isolado em `tmp_path`, com `WORKSPACE_OUTPUT_DIR` apontando para ele.
- `_FakeQAPipeline`: stub que simula o `workflow_qa`. Ele valida que recebeu os manifestos, gera artefatos fake no workspace (`tests/inputs/calculadora.json`, `tests/calculadora/test_calculadora.py`) e devolve o manifesto QA via `EventActions(state_delta=...)`.
- `_fake_runner_constructor`: intercepta a criação do `Runner` no orquestrador, retornando o stub para o `qa_pipeline` e runners vazios para os pipelines anteriores.
- `monkeypatch.setattr("builtins.open", open_spy)`: no teste de dispatcher puro, verifica que o orquestrador não abriu nenhum arquivo.

### 6.3. Execução dos testes da FRENTE 1

Comando executado:

```powershell
cd adk
.venv\Scripts\python.exe -m pytest tests/integration/test_integration_orchestrator_qa.py -v
```

Saída obtida:

```text
============================== test session starts =============================
platform win32 -- Python 3.14.4, pytest-9.0.3, pluggy-1.0
rootdir: C:\Users\leona\Desktop\Programs\AI4ES\adk
configfile: pyproject.toml

tests/integration/test_integration_orchestrator_qa.py::test_orchestrator_envia_manifesto_ao_qa_e_recebe_manifesto_qa PASSED
tests/integration/test_integration_orchestrator_qa.py::test_build_manifest_input_e_leve_e_nao_inclui_conteudo PASSED
tests/integration/test_integration_orchestrator_qa.py::test_manifest_status_ok_proibe_duvida_bloqueante PASSED
tests/integration/test_integration_orchestrator_qa.py::test_manifest_status_blocked_exige_duvida_bloqueante PASSED
tests/integration/test_integration_orchestrator_qa.py::test_orchestrator_e_roteador_puro_sem_open_em_arquivos PASSED

============================== 5 passed, 0 failed ==============================
```

### 6.4. Testes de regressão

Para garantir que a mudança não quebrou o comportamento existente do orquestrador e do workflow_qa, executou-se a suite relacionada:

```powershell
.venv\Scripts\python.exe -m pytest tests/integration/test_integration_orchestrator_qa.py tests/unit/test_orchestrator_helpers.py tests/unit/test_orchestrator_hitl.py tests/unit/test_orchestrator_retry.py tests/integration/test_hitl_e2e.py -v
```

Saída obtida:

```text
============================== test session starts =============================
platform win32 -- Python 3.14.4, pytest-9.0.3, pluggy-1.0
rootdir: C:\Users\leona\Desktop\Programs\AI4ES\adk
configfile: pyproject.toml

tests/integration/test_integration_orchestrator_qa.py::test_orchestrator_envia_manifesto_ao_qa_e_recebe_manifesto_qa PASSED
tests/integration/test_integration_orchestrator_qa.py::test_build_manifest_input_e_leve_e_nao_inclui_conteudo PASSED
tests/integration/test_integration_orchestrator_qa.py::test_manifest_status_ok_proibe_duvida_bloqueante PASSED
tests/integration/test_integration_orchestrator_qa.py::test_manifest_status_blocked_exige_duvida_bloqueante PASSED
tests/integration/test_integration_orchestrator_qa.py::test_orchestrator_e_roteador_puro_sem_open_em_arquivos PASSED
tests/unit/test_orchestrator_helpers.py::test_parse_decision_exato PASSED
tests/unit/test_orchestrator_helpers.py::test_parse_decision_case_insensitive PASSED
... (demais testes de helpers)
tests/unit/test_orchestrator_hitl.py::test_fresh_run_sem_pausa_executa_4_pipelines PASSED
tests/unit/test_orchestrator_hitl.py::test_fresh_run_com_pausa_para_em_qa PASSED
... (demais testes de HITL)
tests/unit/test_orchestrator_retry.py::test_empty_response_triggers_retry PASSED
... (demais testes de retry)
tests/integration/test_hitl_e2e.py::test_orchestrator_pausa_real_e_resume_via_runner_adk PASSED

============================== 39 passed, 0 failed =============================
```

Também foram executados testes do QA Agent:

```powershell
.venv\Scripts\python.exe -m pytest tests/unit/test_qa_workspace_binding.py tests/unit/test_receive_requirements_sanitizer.py tests/unit/test_planner_wrapper.py tests/unit/test_hitl_tool.py -v
```

Resultado: **29 passed, 1 failed**. A única falha (`test_pytest_runner_resolve_dynamic_base`) é **pré-existente** e não relacionada a esta implementação — ela já está documentada em `TIME_3_TESTES.md` como "dead code path" no `pytest_runner.py`.

### 6.5. Falhas pré-existentes identificadas

Durante a execução da suite completa (`pytest tests/`), alguns testes falharam por problemas já existentes no projeto, não causados por esta frente:

| Teste | Motivo da falha | Relacionado a esta frente? |
|---|---|---|
| `test_pytest_runner_resolve_dynamic_base` | `_normalizar_caminho_arquivo` resolve caminho para `tests/hu_001/` em vez de `tests/inputs/hu_001/`. | Não — dead code documentado. |
| `test_get_workspace_root_til_expandido` | No Windows, `Path.expanduser()` não usa a env `HOME` mockada pelo teste. | Não — problema de ambiente Windows. |
| `test_protecao_anti_symlink` | Windows não permite criar symlinks sem privilégios elevados. | Não — problema de ambiente Windows. |
| Diversos testes de filesystem/cr_executor/review | Esperam paths com `/`, mas o Windows retorna `\`. | Não — incompatibilidade pré-existente com Windows. |

Nenhuma dessas falhas impede a validação da FRENTE 1, cujos testes passam integralmente.

---

## 7. Decisões Arquiteturais

### 7.1. Por que Pydantic v2?

- Garante o schema exato do manifesto em runtime.
- Permite expressar invariantes de negócio como regras de validação.
- Facilita serialização/deserialização entre `state_delta` (dict) e objetos tipados.

### 7.2. Por que `after_agent_callback` no workflow_qa?

- Mantém a responsabilidade de "declarar o que produziu" dentro do próprio Time 3.
- O orquestrador não precisa saber como o QA organiza seus arquivos.
- Alinhado ao princípio de que cada Time é autônomo e self-contained.

### 7.3. Por que o orquestrador não abre arquivos?

- Evita acoplamento entre o dispatcher e o formato dos artefatos.
- Permite que cada Time evolua sua estrutura de pastas sem impactar o orquestrador.
- Reduz drasticamente o consumo de tokens nos handoffs (não cola conteúdo).

### 7.4. Por que manter `accumulated_outputs`?

- Retrocompatibilidade com testes e fluxos legados.
- Em futuras frentes, pode ser removido quando todos os Times emitirem manifestos.

---

## 8. Escopo e Limitações

Esta implementação cobre exclusivamente o **Cenário 1: Comunicação bem-sucedida**.

**Incluído:**

- Passagem de manifesto `coding` → QA.
- Emissão de manifesto `qa` com `status=ok`.
- Validação das invariantes do manifesto.
- Garantia de que o orquestrador é roteador puro.

**Não incluído (próximas frentes):**

- HITL genérico no orquestrador (mecânica já existe, mas não foi alterada nesta frente).
- Leitura real do código a partir do manifesto dentro dos sub-agentes do QA (`receive_requirements` ainda espera `arquivos_apoio` no JSON).
- Geração de `doubts` no manifesto QA a partir dos `DoubtArtifactGenerator`.
- Autocorreção e decisão de `status=partial` com base no resultado do pytest.
- Frontend de visualização de artefatos.

---

## 9. Próximos Passos Sugeridos

1. **Time 4 (Coding)**: emitir manifesto `coding` com `artifacts[].path` apontando para `workspace_output/coder/`.
2. **Time 3 (QA)**: atualizar `receive_requirements` para ler código dos `path` do manifesto em vez de esperar `arquivos_apoio` em base64/texto.
3. **HITL genérico**: mover a mecânica de pausa/resume do `workflow_qa` para um mecanismo genérico no orquestrador, conforme descrito em `TIME_3_TESTES.md`.
4. **Dúvidas**: refletir os `DoubtArtifactGenerator` no campo `doubts` do manifesto QA.
5. **Frontend**: construir interface de visualização de artefatos a partir dos manifestos persistidos por sessão.
