### PR TITLE
add: manifesto

### DIFF
--- a/.idea/AI4ES.iml
+++ b/.idea/AI4ES.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/docs/Time_1_Requisitos/templates" />
+      </list>
+    </option>
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/copilot.data.migration.ask2agent.xml
+++ b/.idea/copilot.data.migration.ask2agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Ask2AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="b74ebd88-e2ca-4709-b549-7f5bdc89164d" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="CopilotPersistence">
+    <persistenceIdMap>
+      <entry key="_/Users/matheusaugustodepaulasoares/CEIA/AI4ES" value="3GQoqF3st0ZDx40CcrDumiSzRQL" />
+    </persistenceIdMap>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;customColor&quot;: &quot;&quot;,
+  &quot;associatedIndex&quot;: 3
+}</component>
+  <component name="ProjectId" id="3GQoqF3st0ZDx40CcrDumiSzRQL" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "ai.playground.ignore.import.keys.banner.in.settings": "true",
+    "git-widget-placeholder": "feature/time2-design-manifesto",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-9b0f141eb926-JavaScript-PY-253.31033.139" />
+        <option value="bundled-python-sdk-2653e85de345-6d6dccd035ac-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-253.31033.139" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="b74ebd88-e2ca-4709-b549-7f5bdc89164d" name="Changes" comment="" />
+      <created>1783913344160</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1783913344160</updated>
+      <workItem from="1783913345542" duration="1629000" />
+      <workItem from="1784584102546" duration="78000" />
+      <workItem from="1784584219678" duration="555000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="github-copilot-workspace">
+    <instructionFileLocations>
+      <option value=".github/instructions" />
+    </instructionFileLocations>
+    <promptFileLocations>
+      <option value=".github/prompts" />
+    </promptFileLocations>
+  </component>
+</project>

--- a/adk/src/agents/workflow_design_pipeline/agent.py
+++ b/adk/src/agents/workflow_design_pipeline/agent.py
@@ -9,6 +9,8 @@ from src.agents.prototyping_specialist.agent import agent as prototyping_special
 from src.agents.validator.agent import agent as validator
 from src.agents.io_agent.agent import agent as io_agent
 
+from .manifest import emit_design_manifest
+
 _DEFAULT_MODEL = "github_copilot/gpt-4"
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -172,4 +174,8 @@ agent = SequentialAgent(
         pipeline_controller,
         parallel_branch,
     ],
+    # Ao encerrar a fase, emite o Manifesto de Design determinístico:
+    # varre workspace_output/design/**, deriva o status do resultado da
+    # validação e dos doubts, e grava em state["design_manifest"].
+    after_agent_callback=emit_design_manifest,
 )

--- a/adk/src/agents/workflow_design_pipeline/manifest.py
+++ b/adk/src/agents/workflow_design_pipeline/manifest.py
@@ -1,0 +1,436 @@
+"""Manifesto de Fase do Time 2 (Design).
+
+Emissor determinístico do **Manifesto de Fase** — o contrato pequeno e
+estruturado que cada Time grava no `session.state` ao terminar, em vez de
+repassar o conteúdo volumoso dos artefatos entre fases.
+
+Este módulo define três coisas:
+
+1. **Schema** — dataclasses `ManifestArtifact`, `ManifestDoubt` e
+   `PhaseManifest`, com serialização JSON-friendly.
+2. **Invariantes** — regras que todo manifesto válido deve respeitar
+   (ex.: `status=ok` ⇒ nenhum doubt bloqueante), verificadas por
+   `PhaseManifest.validate_invariants()`.
+3. **Emissor** — `emit_design_manifest`, um `after_agent_callback` plugado no
+   `SequentialAgent` raiz do pipeline de design. Ao final da fase ele varre
+   `workspace_output/design/**`, deriva o `status` do resultado da validação e
+   dos doubts, monta o manifesto, grava-o em `state["design_manifest"]` e
+   persiste uma cópia em `design/manifest.json` para rastreabilidade.
+
+O conteúdo dos artefatos NUNCA entra no manifesto — apenas `path`, `tipo` e
+`id`. A próxima fase lê do workspace só os `path` de que precisa.
+
+Layout observado em disco (ver `shared/workspace.py::AGENT_DIRS`):
+
+    workspace_output/design/                 análise técnica (.md)   → tipo "analise"
+    workspace_output/design/diagrams/        diagramas Mermaid (.mmd)→ tipo "diagrama"
+    workspace_output/design/prototypes/      protótipos (.html/.css) → tipo "prototipo"
+    workspace_output/design/reports/         relatórios (.md)        → tipo "relatorio"
+    workspace_output/design/validation/      veredicto do validator  → tipo "validacao"
+    workspace_output/design/doubts/          Doubt_Artifacts         → doubts
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Constantes do contrato
+# ──────────────────────────────────────────────────────────────────────────────
+
+PHASE_NAME = "design"
+
+#: Nome do arquivo persistido em disco e chave gravada no session.state.
+MANIFEST_FILENAME = "manifest.json"
+STATE_KEY = "design_manifest"
+
+
+class PhaseStatus:
+    """Estados canônicos de um manifesto de fase."""
+
+    OK = "ok"            # concluída e auto-validada, sem doubts bloqueantes
+    BLOCKED = "blocked"  # doubt bloqueante impede seguir / nada foi produzido
+    PARTIAL = "partial"  # produziu algo com pendências não-bloqueantes
+
+    ALL = (OK, BLOCKED, PARTIAL)
+
+
+#: Marcador usado pelos Doubt_Artifacts para sinalizar bloqueio ativo.
+#: Espelha `design_filesystem.STATUS_BLOCKED` / `check_active_blocks`.
+_STATUS_BLOCKED_MARKER = "**Status:** Bloqueado"
+
+#: Marcadores textuais do veredicto do validator persistido em design/validation.
+_VALIDATION_FAIL_MARKERS = ("REPROVADO", "❌", "valid: false", '"valid": false')
+_VALIDATION_PASS_MARKERS = ("APROVADO", "✅", "valid: true", '"valid": true')
+
+#: Backups e artefatos internos que nunca contam como saída da fase.
+_BACKUP_PREFIX = "_backup_"
+_IGNORED_NAMES = {MANIFEST_FILENAME, ".ai4se_workspace", "io_operations.log"}
+
+
+class ManifestInvariantError(ValueError):
+    """Levantada quando um manifesto viola um invariante do contrato."""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Schema
+# ──────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class ManifestArtifact:
+    """Um arquivo persistido pela fase. `path` é relativo à raiz do repo."""
+
+    tipo: str  # "analise" | "diagrama" | "prototipo" | "relatorio" | "validacao"
+    id: str
+    path: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"tipo": self.tipo, "id": self.id, "path": self.path}
+
+
+@dataclass
+class ManifestDoubt:
+    """Uma dúvida aberta pela fase."""
+
+    id: str
+    severidade: str  # "alta" | "media" | "baixa"
+    bloqueante: bool
+    path: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "severidade": self.severidade,
+            "bloqueante": self.bloqueante,
+            "path": self.path,
+        }
+
+
+@dataclass
+class PhaseManifest:
+    """Manifesto de uma fase do SDLC (aqui, sempre `design`)."""
+
+    phase: str
+    status: str
+    artifacts: list[ManifestArtifact] = field(default_factory=list)
+    doubts: list[ManifestDoubt] = field(default_factory=list)
+    summary: str = ""
+    session_id: str | None = None
+
+    # ── invariantes ──────────────────────────────────────────────────────────
+    def has_blocking_doubt(self) -> bool:
+        return any(d.bloqueante for d in self.doubts)
+
+    def validate_invariants(self) -> None:
+        """Verifica as regras do contrato. Levanta `ManifestInvariantError`.
+
+        Invariantes:
+        - `phase` deve ser o nome canônico da fase.
+        - `status` deve ser um dos valores canônicos.
+        - Doubt bloqueante ⇒ `status == blocked`.
+        - `status == ok` ⇒ nenhum doubt bloqueante (auto-validado).
+        - `status == ok` ⇒ ao menos um artefato produzido.
+        """
+        if self.phase != PHASE_NAME:
+            raise ManifestInvariantError(
+                f"phase inválida: {self.phase!r} (esperado {PHASE_NAME!r})"
+            )
+        if self.status not in PhaseStatus.ALL:
+            raise ManifestInvariantError(
+                f"status inválido: {self.status!r} (esperado um de {PhaseStatus.ALL})"
+            )
+        if self.has_blocking_doubt() and self.status != PhaseStatus.BLOCKED:
+            raise ManifestInvariantError(
+                "há doubt bloqueante mas status != 'blocked' "
+                f"(status={self.status!r})"
+            )
+        if self.status == PhaseStatus.OK:
+            if self.has_blocking_doubt():
+                raise ManifestInvariantError(
+                    "status='ok' incompatível com doubt bloqueante"
+                )
+            if not self.artifacts:
+                raise ManifestInvariantError(
+                    "status='ok' exige ao menos um artefato produzido"
+                )
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "phase": self.phase,
+            "status": self.status,
+            "artifacts": [a.to_dict() for a in self.artifacts],
+            "doubts": [d.to_dict() for d in self.doubts],
+            "summary": self.summary,
+        }
+        if self.session_id is not None:
+            data["session_id"] = self.session_id
+        return data
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Varredura do workspace
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _design_root() -> Path:
+    """Raiz do output de design, respeitando WORKSPACE_OUTPUT_DIR.
+
+    Import tardio de `shared.workspace` para evitar acoplar o schema/invariantes
+    (testáveis isoladamente) à camada de workspace.
+    """
+    from shared.workspace import get_workspace_root
+
+    return get_workspace_root() / PHASE_NAME
+
+
+def _repo_relative(path: Path, root: Path) -> str:
+    """Caminho relativo à raiz do repo (o pai de `workspace_output/`).
+
+    Ex.: `<repo>/adk/workspace_output/design/diagrams/HU-001.mmd`
+         → `workspace_output/design/diagrams/HU-001.mmd`.
+    Fallback: caminho absoluto, se a relativização não for possível.
+    """
+    try:
+        base = root.parent.parent  # design/ → workspace_output/ → base
+        return os.path.relpath(path, base)
+    except (ValueError, OSError):
+        return str(path)
+
+
+def _is_relevant_file(f: Path) -> bool:
+    return (
+        f.is_file()
+        and f.name not in _IGNORED_NAMES
+        and _BACKUP_PREFIX not in f.name
+    )
+
+
+def _iter_files(directory: Path) -> list[Path]:
+    if not directory.exists():
+        return []
+    return sorted(p for p in directory.iterdir() if _is_relevant_file(p))
+
+
+def _extract_id(filename: str) -> str:
+    """Deriva um id legível do nome do arquivo (HU-NNN se presente, senão stem)."""
+    stem = Path(filename).stem
+    m = re.search(r"HU-?\d+", stem, flags=re.IGNORECASE)
+    return m.group(0).upper().replace("HU", "HU-").replace("HU--", "HU-") if m else stem
+
+
+def _collect_artifacts(design_root: Path) -> list[ManifestArtifact]:
+    """Varre o subtree de design e classifica cada arquivo por tipo.
+
+    `design/staging` é ignorado — é área de rascunho transitória do io_agent.
+    """
+    mapping = [
+        ("analise", design_root, False),            # apenas o nível raiz de design/
+        ("diagrama", design_root / "diagrams", True),
+        ("prototipo", design_root / "prototypes", True),
+        ("relatorio", design_root / "reports", True),
+        ("validacao", design_root / "validation", True),
+    ]
+    artifacts: list[ManifestArtifact] = []
+    for tipo, directory, recurse in mapping:
+        files = (
+            [p for p in directory.rglob("*") if _is_relevant_file(p)]
+            if recurse
+            else _iter_files(directory)
+        )
+        for f in sorted(files):
+            artifacts.append(
+                ManifestArtifact(
+                    tipo=tipo,
+                    id=_extract_id(f.name),
+                    path=_repo_relative(f, design_root),
+                )
+            )
+    return artifacts
+
+
+def _collect_doubts(design_root: Path) -> list[ManifestDoubt]:
+    """Localiza Doubt_Artifacts no subtree de design e classifica bloqueio.
+
+    Espelha a convenção de `design_filesystem.check_active_blocks`: um doubt é
+    bloqueante se seu conteúdo contém `**Status:** Bloqueado`.
+    """
+    doubts: list[ManifestDoubt] = []
+    for f in sorted(design_root.rglob("*")):
+        if not _is_relevant_file(f):
+            continue
+        if not f.name.lower().startswith("doubt"):
+            continue
+        try:
+            content = f.read_text(encoding="utf-8")
+        except OSError:
+            content = ""
+        bloqueante = _STATUS_BLOCKED_MARKER in content
+        doubts.append(
+            ManifestDoubt(
+                id=_extract_id(f.name),
+                severidade="alta" if bloqueante else "media",
+                bloqueante=bloqueante,
+                path=_repo_relative(f, design_root),
+            )
+        )
+    return doubts
+
+
+def _validation_verdict(design_root: Path) -> str:
+    """Lê o veredicto do validator em design/validation.
+
+    Retorna "pass", "fail" ou "absent". O `ok` do manifesto exige "pass" —
+    espelha a regra do design doc: "status=ok só após a validação passar".
+    """
+    validation_dir = design_root / "validation"
+    files = [p for p in _iter_files(validation_dir)]
+    if not files:
+        return "absent"
+
+    saw_pass = False
+    for f in files:
+        try:
+            content = f.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if any(marker in content for marker in _VALIDATION_FAIL_MARKERS):
+            return "fail"
+        if any(marker in content for marker in _VALIDATION_PASS_MARKERS):
+            saw_pass = True
+    return "pass" if saw_pass else "absent"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Derivação de status (determinística)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _derive_status(
+    artifacts: list[ManifestArtifact],
+    doubts: list[ManifestDoubt],
+    validation: str,
+) -> str:
+    """Deriva o status conforme os invariantes do contrato.
+
+    Precedência:
+    1. Doubt bloqueante  → BLOCKED (invariante do contrato).
+    2. Nenhum artefato   → BLOCKED (a fase não produziu design).
+    3. Validação reprovada / ausente → PARTIAL (produziu, sem validação verde).
+    4. Validação aprovada → OK.
+    """
+    if any(d.bloqueante for d in doubts):
+        return PhaseStatus.BLOCKED
+    if not artifacts:
+        return PhaseStatus.BLOCKED
+    if validation == "pass":
+        return PhaseStatus.OK
+    return PhaseStatus.PARTIAL
+
+
+def _build_summary(
+    status: str,
+    artifacts: list[ManifestArtifact],
+    doubts: list[ManifestDoubt],
+    validation: str,
+) -> str:
+    counts: dict[str, int] = {}
+    for a in artifacts:
+        counts[a.tipo] = counts.get(a.tipo, 0) + 1
+    parts = ", ".join(f"{n} {tipo}" for tipo, n in sorted(counts.items())) or "nenhum artefato"
+    n_bloq = sum(1 for d in doubts if d.bloqueante)
+    doubt_txt = (
+        f"{len(doubts)} doubt(s) ({n_bloq} bloqueante(s))" if doubts else "sem doubts"
+    )
+    return (
+        f"Fase design concluída com status '{status}'. "
+        f"Artefatos: {parts}. Validação: {validation}. {doubt_txt}."
+    )
+
+
+def build_design_manifest(
+    design_root: Path | None = None,
+    session_id: str | None = None,
+) -> PhaseManifest:
+    """Monta (e valida) o manifesto de design a partir do disco.
+
+    Função pura sobre o filesystem — testável sem o runtime ADK.
+    """
+    root = design_root if design_root is not None else _design_root()
+    artifacts = _collect_artifacts(root)
+    doubts = _collect_doubts(root)
+    validation = _validation_verdict(root)
+    status = _derive_status(artifacts, doubts, validation)
+    summary = _build_summary(status, artifacts, doubts, validation)
+
+    manifest = PhaseManifest(
+        phase=PHASE_NAME,
+        status=status,
+        artifacts=artifacts,
+        doubts=doubts,
+        summary=summary,
+        session_id=session_id,
+    )
+    manifest.validate_invariants()
+    return manifest
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Emissor — after_agent_callback
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _persist_manifest(design_root: Path, manifest: PhaseManifest) -> None:
+    """Grava uma cópia legível do manifesto em design/manifest.json."""
+    try:
+        design_root.mkdir(parents=True, exist_ok=True)
+        target = design_root / MANIFEST_FILENAME
+        target.write_text(
+            json.dumps(manifest.to_dict(), ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:  # persistência é best-effort — o state é a fonte de verdade
+        logger.warning("[design_manifest] falha ao persistir manifest.json: %s", exc)
+
+
+def _session_id_from(callback_context: Any) -> str | None:
+    try:
+        return callback_context._invocation_context.session.id
+    except AttributeError:
+        return None
+
+
+def emit_design_manifest(callback_context: Any) -> None:
+    """`after_agent_callback` do pipeline de design.
+
+    Varre o workspace, deriva o manifesto e grava-o em `state["design_manifest"]`
+    (o handoff para a próxima fase) e em `design/manifest.json` (rastreabilidade).
+
+    Retorna `None` para não substituir a saída do agente (contrato ADK: um
+    callback que retorna `types.Content` sobrescreve a resposta; `None` a mantém).
+    """
+    try:
+        design_root = _design_root()
+        session_id = _session_id_from(callback_context)
+        manifest = build_design_manifest(design_root, session_id=session_id)
+    except Exception as exc:  # emissor nunca deve derrubar o pipeline
+        logger.exception("[design_manifest] falha ao emitir manifesto: %s", exc)
+        return None
+
+    try:
+        callback_context.state[STATE_KEY] = manifest.to_dict()
+    except Exception as exc:
+        logger.warning("[design_manifest] falha ao gravar no state: %s", exc)
+
+    _persist_manifest(design_root, manifest)
+    logger.info(
+        "[design_manifest] status=%s artefatos=%d doubts=%d",
+        manifest.status,
+        len(manifest.artifacts),
+        len(manifest.doubts),
+    )
+    return None

--- a/adk/tests/unit/test_design_manifest.py
+++ b/adk/tests/unit/test_design_manifest.py
@@ -1,0 +1,210 @@
+"""Testes do emissor de Manifesto de Design (Time 2).
+
+Cobre schema, invariantes e derivação de status a partir do disco
+(`build_design_manifest`), além do wiring do `after_agent_callback` no
+`SequentialAgent` raiz e da escrita no `session.state`.
+
+Não usa o runtime ADK: a varredura é uma função pura sobre o filesystem e o
+`CallbackContext` é substituído por um duplo mínimo com `.state`.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.agents.workflow_design_pipeline.manifest import (
+    ManifestArtifact,
+    ManifestDoubt,
+    ManifestInvariantError,
+    PhaseManifest,
+    PhaseStatus,
+    STATE_KEY,
+    MANIFEST_FILENAME,
+    build_design_manifest,
+    emit_design_manifest,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers de fixture — monta uma árvore design/ em tmp_path
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _write(path: Path, content: str = "conteudo") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _design_tree(
+    tmp_path: Path,
+    *,
+    analysis: bool = True,
+    diagram: bool = True,
+    report: bool = True,
+    validation: str | None = "pass",  # "pass" | "fail" | None
+    doubt: str | None = None,         # "blocked" | "open" | None
+) -> Path:
+    """Cria workspace_output/design/** e retorna o design_root."""
+    root = tmp_path / "workspace_output" / "design"
+    root.mkdir(parents=True, exist_ok=True)
+    if analysis:
+        _write(root / "analise_tecnica_HU-001.md")
+    if diagram:
+        _write(root / "diagrams" / "diagrama_HU-001.mmd")
+    if report:
+        _write(root / "reports" / "relatorio_HU-001.md")
+    if validation == "pass":
+        _write(root / "validation" / "veredicto.md", "✅ APROVADO — tudo certo")
+    elif validation == "fail":
+        _write(root / "validation" / "veredicto.md", "❌ REPROVADO — grammar")
+    if doubt == "blocked":
+        _write(root / "doubts" / "Doubt_Artifact_HU-002.md", "**Status:** Bloqueado")
+    elif doubt == "open":
+        _write(root / "doubts" / "Doubt_Artifact_HU-003.md", "**Status:** Resolvido")
+    return root
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Schema + invariantes
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_ok_manifesto_serializa_com_campos_do_contrato():
+    m = PhaseManifest(
+        phase="design",
+        status=PhaseStatus.OK,
+        artifacts=[ManifestArtifact("analise", "HU-001", "workspace_output/design/a.md")],
+        summary="ok",
+    )
+    m.validate_invariants()
+    d = m.to_dict()
+    assert set(d) >= {"phase", "status", "artifacts", "doubts", "summary"}
+    assert d["artifacts"][0] == {
+        "tipo": "analise",
+        "id": "HU-001",
+        "path": "workspace_output/design/a.md",
+    }
+
+
+def test_invariante_doubt_bloqueante_exige_status_blocked():
+    m = PhaseManifest(
+        phase="design",
+        status=PhaseStatus.PARTIAL,
+        artifacts=[ManifestArtifact("analise", "HU-001", "a.md")],
+        doubts=[ManifestDoubt("D-1", "alta", True, "d.md")],
+    )
+    with pytest.raises(ManifestInvariantError):
+        m.validate_invariants()
+
+
+def test_invariante_ok_exige_algum_artefato():
+    m = PhaseManifest(phase="design", status=PhaseStatus.OK, artifacts=[])
+    with pytest.raises(ManifestInvariantError):
+        m.validate_invariants()
+
+
+def test_invariante_status_desconhecido_rejeitado():
+    m = PhaseManifest(phase="design", status="done")
+    with pytest.raises(ManifestInvariantError):
+        m.validate_invariants()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Derivação de status a partir do disco
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_status_ok_quando_validacao_passa_sem_doubt(tmp_path):
+    root = _design_tree(tmp_path, validation="pass", doubt=None)
+    m = build_design_manifest(root)
+    assert m.status == PhaseStatus.OK
+    tipos = {a.tipo for a in m.artifacts}
+    assert {"analise", "diagrama", "relatorio", "validacao"} <= tipos
+
+
+def test_status_partial_quando_validacao_ausente(tmp_path):
+    root = _design_tree(tmp_path, validation=None, doubt=None)
+    m = build_design_manifest(root)
+    assert m.status == PhaseStatus.PARTIAL
+
+
+def test_status_partial_quando_validacao_reprova(tmp_path):
+    root = _design_tree(tmp_path, validation="fail", doubt=None)
+    m = build_design_manifest(root)
+    assert m.status == PhaseStatus.PARTIAL
+
+
+def test_status_blocked_quando_doubt_bloqueante_mesmo_com_validacao_verde(tmp_path):
+    root = _design_tree(tmp_path, validation="pass", doubt="blocked")
+    m = build_design_manifest(root)
+    assert m.status == PhaseStatus.BLOCKED
+    assert m.has_blocking_doubt()
+    # invariante segura: build nunca devolve ok com bloqueio
+    m.validate_invariants()
+
+
+def test_doubt_resolvido_nao_e_bloqueante(tmp_path):
+    root = _design_tree(tmp_path, validation="pass", doubt="open")
+    m = build_design_manifest(root)
+    assert not m.has_blocking_doubt()
+    assert m.status == PhaseStatus.OK
+
+
+def test_status_blocked_quando_nada_produzido(tmp_path):
+    root = _design_tree(
+        tmp_path, analysis=False, diagram=False, report=False, validation=None
+    )
+    m = build_design_manifest(root)
+    assert m.status == PhaseStatus.BLOCKED
+    assert m.artifacts == []
+
+
+def test_backups_e_manifest_json_sao_ignorados(tmp_path):
+    root = _design_tree(tmp_path, validation="pass")
+    _write(root / "analise_tecnica_HU-001_backup_20250101.md")
+    _write(root / MANIFEST_FILENAME, "{}")
+    m = build_design_manifest(root)
+    paths = [a.path for a in m.artifacts]
+    assert not any("_backup_" in p for p in paths)
+    assert not any(p.endswith(MANIFEST_FILENAME) for p in paths)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Emissor (after_agent_callback) + wiring
+# ──────────────────────────────────────────────────────────────────────────────
+
+class _FakeCtx:
+    """Duplo mínimo de CallbackContext: expõe apenas `.state`."""
+
+    def __init__(self):
+        self.state = {}
+
+
+def test_emissor_grava_state_e_persiste_json(tmp_path, monkeypatch):
+    _design_tree(tmp_path, validation="pass")
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "workspace_output"))
+
+    ctx = _FakeCtx()
+    result = emit_design_manifest(ctx)
+
+    assert result is None  # não sobrescreve a saída do agente
+    assert STATE_KEY in ctx.state
+    assert ctx.state[STATE_KEY]["status"] == PhaseStatus.OK
+
+    manifest_json = tmp_path / "workspace_output" / "design" / MANIFEST_FILENAME
+    assert manifest_json.exists()
+
+
+def test_emissor_nao_derruba_pipeline_sem_workspace(tmp_path, monkeypatch):
+    # Aponta para um workspace inexistente: emissor deve degradar sem exceção.
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "vazio"))
+    ctx = _FakeCtx()
+    # nada produzido → status blocked, sem exceção
+    assert emit_design_manifest(ctx) is None
+    assert ctx.state[STATE_KEY]["status"] == PhaseStatus.BLOCKED
+
+
+def test_root_agent_tem_after_agent_callback_de_manifesto():
+    from src.agents.workflow_design_pipeline.agent import agent
+    from src.agents.workflow_design_pipeline.manifest import emit_design_manifest
+
+    callbacks = agent.canonical_after_agent_callbacks
+    assert emit_design_manifest in callbacks


### PR DESCRIPTION
# Time 2 — Design: emissor de Manifesto de Fase (schema + invariantes)
Ref #292 
## Contexto

Parte da refatoração que torna o `orchestrator` um dispatcher fino e cada Time SWEBOK autônomo. Hoje o handoff entre fases passa o output completo truncado em ~8000 chars — anti-padrão que custa tokens e escala mal (>50 HUs reincidem em token overflow). A forma nativa do ADK é **artefatos para dados volumosos + um manifesto pequeno e estruturado para o handoff**.

Não havia nenhuma ocorrência de "manifesto" no código do Time 2. Este PR cria o emissor para a fase de design.

## O que muda

- **Schema** (`manifest.py`): dataclasses `PhaseManifest`, `ManifestArtifact`, `ManifestDoubt`, serializando exatamente os campos do contrato (`phase`, `status`, `artifacts[tipo,id,path]`, `doubts[id,severidade,bloqueante,path]`, `summary`). O conteúdo dos artefatos **nunca** entra no manifesto — só `path`, `tipo` e `id`.
- **Invariantes** (`validate_invariants()`): `phase`/`status` canônicos; doubt bloqueante ⇒ `status=blocked`; `status=ok` ⇒ sem doubts bloqueantes **e** ao menos um artefato. Viola → `ManifestInvariantError`.
- **Emissor** (`emit_design_manifest`): plugado como `after_agent_callback` no `SequentialAgent` raiz do pipeline de design. Ao encerrar a fase, varre `workspace_output/design/**`, classifica artefatos por subpasta (`analise`/`diagrama`/`prototipo`/`relatorio`/`validacao`), coleta doubts pela convenção `**Status:** Bloqueado`, **deriva o `status` do resultado do `validator`** em `design/validation/`, grava o manifesto em `state["design_manifest"]` (o handoff para a próxima fase) e persiste uma cópia em `design/manifest.json` para rastreabilidade.
- É **best-effort**: qualquer falha na emissão é logada e degradada, nunca derruba o pipeline. Retorna `None` para não sobrescrever a saída do agente.

## Derivação de status

| Condição | Status |
|---|---|
| Doubt bloqueante presente | `blocked` |
| Nenhum artefato produzido | `blocked` |
| Produziu, mas validação não-verde/ausente | `partial` |
| Validação aprovada, sem bloqueantes | `ok` |

Fiel ao contrato: `status=ok` só após a validação passar.

## Decisões

- **Layout real vs. design doc.** O doc descreve `sessions/<session_id>/design/…`; o código atual usa `workspace_output/design/{,diagrams,reports,validation}` (via `shared/workspace.py::AGENT_DIRS`). Segui o layout real e incluí `session_id` no manifesto para rastreabilidade, sem reestruturar diretórios.
- **Status do `validator`.** O `validator` emite o veredicto como texto (✅/❌) e não persiste um relatório fixo. O emissor lê `design/validation/` por marcadores de aprovação/reprovação, forward-compatible com um artefato de validação persistido no futuro.
- **Dependência T6.** T6 (emissor de requirements) ainda não existe; este PR define `PhaseStatus` (`ok`/`blocked`/`partial`) e os invariantes, que T6 pode reusar.

## Testes

`test_design_manifest.py` — 14 testes cobrindo: serialização do schema, cada invariante, derivação `ok`/`partial`/`blocked` a partir do disco, precedência do doubt bloqueante sobre validação verde, filtro de backups/`manifest.json`, escrita no `state` + persistência, e o wiring do callback no agente raiz. **14 passed**; suites de design existentes seguem verdes (`test_orchestrator_design.py`, `test_design_workspace_binding.py`).

## Fora de escopo

- Reescrita do prompt do `design_architect` para ler os paths do manifesto de requisitos (input via manifesto).
- HITL próprio do design via `LongRunningFunctionTool`.
- Emissor de requirements (T6).