### PR TITLE
refactor(reviewer): substitui _review_persister por after_agent_callback

### DIFF
--- a/adk/src/agents/workflow_coding_review/cr_reviewer.py
+++ b/adk/src/agents/workflow_coding_review/cr_reviewer.py
@@ -146,8 +146,11 @@ def _persist_review(callback_context: CallbackContext) -> None:
         RuntimeError: se tool_salvar_relatorio retornar sucesso=False
             (cobre tanto falha de I/O quanto parametros invalidos).
     """
-    analysis = callback_context.state.get("review_analysis", "")
-    if not analysis:
+    analysis_raw = callback_context.state.get("review_analysis")
+    if analysis_raw is None:
+        return
+    analysis = str(analysis_raw)
+    if not analysis.strip():
         return
     result = tool_salvar_relatorio(
         conteudo=analysis,

--- a/adk/src/agents/workflow_coding_review/cr_reviewer.py
+++ b/adk/src/agents/workflow_coding_review/cr_reviewer.py
@@ -143,7 +143,8 @@ def _persist_review(callback_context: CallbackContext) -> None:
     diretamente em Python, eliminando o risco de modo narrador.
 
     Raises:
-        RuntimeError: se tool_salvar_relatorio reportar falha de I/O.
+        RuntimeError: se tool_salvar_relatorio retornar sucesso=False
+            (cobre tanto falha de I/O quanto parametros invalidos).
     """
     analysis = callback_context.state.get("review_analysis", "")
     if not analysis:

--- a/adk/src/agents/workflow_coding_review/cr_reviewer.py
+++ b/adk/src/agents/workflow_coding_review/cr_reviewer.py
@@ -46,7 +46,7 @@ def _discover_coder_files() -> str:
     if not coder_dir.exists():
         return "- (nenhum arquivo ainda — coder será executado antes de você)"
     files = sorted(
-        str(p.relative_to(coder_dir))
+        p.relative_to(coder_dir).as_posix()
         for p in coder_dir.rglob("*")
         if p.is_file() and "__pycache__" not in p.parts
     )

--- a/adk/src/agents/workflow_coding_review/cr_reviewer.py
+++ b/adk/src/agents/workflow_coding_review/cr_reviewer.py
@@ -101,7 +101,7 @@ _ANALYZER_BASE = (
         "  \"report_path\": \"verificacao_revisao.md\"\n"
         "}\n"
         "\n"
-        "Use \"APROVADO\" ou \"BLOQUEADO\" no título \"## Status:\".",
+        "Use \"APROVADO\" ou \"BLOQUEADO\" no campo `status`.",
         "# SAÍDA\n"
         "Sua responsabilidade é PRODUZIR A ANÁLISE em markdown — a persistência em disco\n"
         "é feita automaticamente pelo pipeline após sua resposta.\n"

--- a/adk/src/agents/workflow_coding_review/cr_reviewer.py
+++ b/adk/src/agents/workflow_coding_review/cr_reviewer.py
@@ -101,7 +101,7 @@ _ANALYZER_BASE = (
         "  \"report_path\": \"verificacao_revisao.md\"\n"
         "}\n"
         "\n"
-        "Use \"APROVADO\" ou \"BLOQUEADO\" no campo `status`.",
+        "Use \"APROVADO\" ou \"BLOQUEADO\" no título \"## Status:\".",
         "# SAÍDA\n"
         "Sua responsabilidade é PRODUZIR A ANÁLISE em markdown — a persistência em disco\n"
         "é feita automaticamente pelo pipeline após sua resposta.\n"
@@ -144,7 +144,7 @@ def _persist_review(callback_context: CallbackContext) -> None:
 
     Raises:
         RuntimeError: se tool_salvar_relatorio retornar sucesso=False
-            (cobre tanto falha de I/O quanto parametros invalidos).
+            (cobre tanto falha de I/O quanto parâmetros inválidos).
     """
     analysis_raw = callback_context.state.get("review_analysis")
     if analysis_raw is None:

--- a/adk/src/agents/workflow_coding_review/cr_reviewer.py
+++ b/adk/src/agents/workflow_coding_review/cr_reviewer.py
@@ -1,21 +1,28 @@
-"""Reviewer dedicado ao workflow coding_review (2 fases: analyzer + persister).
+"""Reviewer dedicado ao workflow coding_review.
 
 Instância ajustada do reviewer original (src/agents/reviewer/):
-- Analyzer: lê arquivos de coder/src/ (não diff git), produz markdown.
-- Persister: persiste o relatório em coder/review/ via tool_salvar_relatorio.
+- Analyzer: lê arquivos de coder/src/ (não diff git), produz análise markdown.
+- Persistência via after_agent_callback Python puro — sem LLM no passo de escrita.
+  Isso elimina o risco de "modo narrador" (LLM descreve a chamada em vez de executá-la).
 - Evita conflito de parent com o sdlc_pipeline (instância dedicada).
 """
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
-from google.adk.agents import LlmAgent, SequentialAgent
+from google.adk.agents import LlmAgent
 from google.adk.tools import FunctionTool
 
 from shared.agent_factory import _bind_tool_to_workspace
 from shared.workspace import get_agent_workspace, get_workspace_root
 from shared.tools import tool_ler_arquivo, tool_salvar_relatorio
 from src.agents.reviewer import prompt as reviewer_prompt
+
+if TYPE_CHECKING:
+    from google.adk.agents.callback_context import CallbackContext
+else:
+    CallbackContext = Any  # type: ignore[misc,assignment]
 
 _DEFAULT_MODEL = "gemini-2.5-flash"
 _model = os.environ.get("ADK_LLM_MODEL", _DEFAULT_MODEL)
@@ -49,12 +56,12 @@ def _discover_coder_files() -> str:
 
 
 # ---------------------------------------------------------------------------
-# Fase 1: Analyzer (reutiliza "alma" de src/agents/reviewer/prompt.py)
+# Analyzer (reutiliza "alma" de src/agents/reviewer/prompt.py)
 # ---------------------------------------------------------------------------
 # Composição: prompt original do reviewer ajustado para:
 # - Ler arquivos do workspace (não diff git)
-# - Produzir markdown (não JSON) — a persistência é do persister
-# - Não chamar tool_salvar_relatorio — responsabilidade do persister
+# - Produzir markdown — persistência feita via after_agent_callback
+# - Não chamar tool_salvar_relatorio — responsabilidade do callback
 
 _ANALYZER_BASE = (
     reviewer_prompt.instruction
@@ -96,15 +103,15 @@ _ANALYZER_BASE = (
         "\n"
         "Use \"APROVADO\" ou \"BLOQUEADO\" no campo `status`.",
         "# SAÍDA\n"
-        "Você é a FASE 1 de um pipeline de revisão de 2 fases. Sua única responsabilidade\n"
-        "é PRODUZIR A ANÁLISE — outro agente vai persistir o relatório no próximo passo.\n"
+        "Sua responsabilidade é PRODUZIR A ANÁLISE em markdown — a persistência em disco\n"
+        "é feita automaticamente pelo pipeline após sua resposta.\n"
         "\n"
         "Produza markdown com seções:\n"
         "- \"## Status: APROVADO\" ou \"## Status: BLOQUEADO\"\n"
         "- \"## Issues\" (lista por severidade com arquivo/camada/descrição)\n"
         "- \"## Resumo\" (1 parágrafo)\n"
         "\n"
-        "NÃO produza JSON literal. NÃO tente salvar nada — você não tem essa capacidade nesta fase.",
+        "NÃO produza JSON literal.",
     )
 )
 
@@ -128,58 +135,42 @@ def _analyzer_instruction_provider(_ctx) -> str:
     )
 
 
+def _persist_review(callback_context: CallbackContext) -> None:
+    """Persiste o relatório de revisão no disco — zero LLM no passo de escrita.
+
+    Executado pelo runtime do ADK após _analyzer terminar.
+    Lê review_analysis do callback_context.state e chama tool_salvar_relatorio
+    diretamente em Python, eliminando o risco de modo narrador.
+
+    Raises:
+        RuntimeError: se tool_salvar_relatorio reportar falha de I/O.
+    """
+    analysis = callback_context.state.get("review_analysis", "")
+    if not analysis:
+        return
+    result = tool_salvar_relatorio(
+        conteudo=analysis,
+        nome_arquivo="verificacao_revisao.md",
+        base_dir=_REVIEW_WS,
+    )
+    if not result.get("sucesso"):
+        raise RuntimeError(
+            f"Falha ao persistir relatório de revisão: {result.get('erro')}"
+        )
+
+
 _analyzer = LlmAgent(
     model=_model,
     name="cr_review_analyzer",
-    description="Fase 1 de revisão: lê código do coder e produz análise em markdown.",
+    description="Revisão de código: lê arquivos do coder, produz análise markdown e persiste via callback.",
     instruction=_analyzer_instruction_provider,
     output_key="review_analysis",
     tools=[
         _bind(FunctionTool(tool_ler_arquivo), _CODER_WS),
     ],
 )
+_analyzer.after_agent_callback = _persist_review
 
-# ---------------------------------------------------------------------------
-# Fase 2: Persister
-# ---------------------------------------------------------------------------
-
-_PERSISTER_INSTRUCTION = """
-Você é a FASE 2 de um pipeline de revisão de código.
-
-A análise foi produzida pela fase anterior e está disponível abaixo:
-
----ANALISE---
-{review_analysis}
----FIM ANALISE---
-
-AÇÃO ÚNICA E OBRIGATÓRIA:
-Chame tool_salvar_relatorio com:
-  - nome_arquivo: "verificacao_revisao.md"
-  - conteudo: o texto entre ---ANALISE--- e ---FIM ANALISE--- acima, EXATAMENTE como recebido.
-
-NÃO responda com texto além da chamada da tool.
-NÃO escreva a chamada como código Python descritivo (ex: NÃO escreva
-`default_api.tool_salvar_relatorio(...)` como texto). FAÇA a function call real.
-NÃO modifique o conteúdo da análise — apenas persista.
-"""
-
-_persister = LlmAgent(
-    model=_model,
-    name="cr_review_persister",
-    description="Fase 2 de revisão: persiste o relatório produzido pelo analyzer.",
-    instruction=_PERSISTER_INSTRUCTION,
-    output_key="review",
-    tools=[
-        _bind(FunctionTool(tool_salvar_relatorio), _REVIEW_WS),
-    ],
-)
-
-# ---------------------------------------------------------------------------
-# Agente exportado: SequentialAgent que agrupa as 2 fases
-# ---------------------------------------------------------------------------
-
-agent = SequentialAgent(
-    name="cr_review_agent",
-    description="Pipeline de revisão em 2 fases: análise + persistência.",
-    sub_agents=[_analyzer, _persister],
-)
+# agent é exportado como LlmAgent (not SequentialAgent) — a persistência acontece
+# via after_agent_callback, sem necessidade de um segundo agente no pipeline.
+agent = _analyzer

--- a/adk/src/agents/workflow_coding_review/cr_reviewer.py
+++ b/adk/src/agents/workflow_coding_review/cr_reviewer.py
@@ -159,7 +159,8 @@ def _persist_review(callback_context: CallbackContext) -> None:
     )
     if not result.get("sucesso"):
         raise RuntimeError(
-            f"Falha ao persistir relatório de revisão: {result.get('erro')}"
+            "Falha ao persistir relatório de revisão em "
+            f"'{result.get('caminho') or 'verificacao_revisao.md'}': {result.get('erro')}"
         )
 
 

--- a/adk/tests/unit/test_review_agent_persistence.py
+++ b/adk/tests/unit/test_review_agent_persistence.py
@@ -176,3 +176,62 @@ def test_persist_review_nao_cria_arquivo_se_analysis_vazia(tmp_path, monkeypatch
 
     relatorio = review_ws / "verificacao_revisao.md"
     assert not relatorio.exists(), "Não deveria criar arquivo com analysis vazia"
+
+
+def test_adk_runner_dispara_after_agent_callback(tmp_path, monkeypatch):
+    """Verifica que o ADK Runner dispara after_agent_callback após _analyzer completar.
+
+    Usa before_model_callback para bypassar a chamada real ao Gemini — o ADK
+    trata a resposta fake como output do agente, salva em state via output_key,
+    e então dispara after_agent_callback (_persist_review).
+    """
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+
+    import importlib
+    from src.agents.workflow_coding_review import cr_reviewer
+    importlib.reload(cr_reviewer)
+
+    review_ws = Path(cr_reviewer._REVIEW_WS)
+    review_ws.mkdir(parents=True, exist_ok=True)
+
+    from google.adk.models.llm_response import LlmResponse
+    from google.adk.runners import Runner
+    from google.adk.sessions import InMemorySessionService
+    from google.genai import types as genai_types
+
+    fake_analysis = "## Status: APROVADO\n\n## Issues\nNenhum.\n\n## Resumo\nCodigo ok."
+
+    def _stub_llm(_callback_ctx, _llm_request):
+        """Bypassa chamada real ao Gemini — retorna análise fake."""
+        return LlmResponse(
+            content=genai_types.Content(
+                role="model",
+                parts=[genai_types.Part(text=fake_analysis)],
+            )
+        )
+
+    cr_reviewer._analyzer.before_model_callback = _stub_llm
+    try:
+        session_svc = InMemorySessionService()
+        runner = Runner(
+            agent=cr_reviewer._analyzer,
+            app_name="test_persist",
+            session_service=session_svc,
+            auto_create_session=True,
+        )
+        list(runner.run(
+            user_id="test_user",
+            session_id="test_session",
+            new_message=genai_types.Content(
+                parts=[genai_types.Part(text="revisar")]
+            ),
+        ))
+    finally:
+        cr_reviewer._analyzer.before_model_callback = None
+
+    relatorio = review_ws / "verificacao_revisao.md"
+    assert relatorio.exists(), (
+        "after_agent_callback não foi disparado pelo ADK Runner — "
+        "verificacao_revisao.md não foi criado"
+    )
+    assert "APROVADO" in relatorio.read_text(encoding="utf-8")

--- a/adk/tests/unit/test_review_agent_persistence.py
+++ b/adk/tests/unit/test_review_agent_persistence.py
@@ -1,9 +1,12 @@
-"""Tests para o cr_review_agent do workflow_coding_review.
+"""Testes para o cr_reviewer do workflow_coding_review.
 
 Cobertura:
 - _discover_coder_files lista arquivos do workspace do coder
-- O InstructionProvider injeta a lista + a substring obrigatória de save
-- As tools tool_ler_arquivo e tool_salvar_relatorio estão bound aos workspaces certos
+- O InstructionProvider injeta a lista de arquivos no momento da invocação
+- tool_ler_arquivo está bound ao workspace do coder
+- _analyzer tem after_agent_callback configurado (_persist_review)
+- agent é alias direto de _analyzer (sem LlmAgent intermediário para o save)
+- O callback _persist_review escreve verificacao_revisao.md no workspace do reviewer
 """
 
 from pathlib import Path
@@ -32,7 +35,6 @@ def test_discover_coder_files_lista_arquivos_relativos(tmp_path, monkeypatch):
     from src.agents.workflow_coding_review import cr_reviewer
     importlib.reload(cr_reviewer)
 
-    # Cria arquivos APÓS o reload (init_workspace limpa o diretório no reload)
     coder_ws = Path(cr_reviewer._CODER_WS)
     (coder_ws / "app").mkdir(parents=True, exist_ok=True)
     (coder_ws / "app" / "main.py").write_text("# main")
@@ -53,7 +55,6 @@ def test_discover_coder_files_ignora_pycache(tmp_path, monkeypatch):
     from src.agents.workflow_coding_review import cr_reviewer
     importlib.reload(cr_reviewer)
 
-    # Cria arquivos APÓS o reload (init_workspace limpa o diretório no reload)
     coder_ws = Path(cr_reviewer._CODER_WS)
     (coder_ws / "app" / "__pycache__").mkdir(parents=True, exist_ok=True)
     (coder_ws / "app" / "__pycache__" / "main.cpython-312.pyc").write_bytes(b"x")
@@ -66,14 +67,13 @@ def test_discover_coder_files_ignora_pycache(tmp_path, monkeypatch):
 
 
 def test_review_analyzer_instruction_provider_inclui_arquivos_descobertos(tmp_path, monkeypatch):
-    """O instruction provider do _review_analyzer chama _discover_coder_files e injeta no template."""
+    """O instruction provider do _analyzer chama _discover_coder_files e injeta no template."""
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
 
     import importlib
     from src.agents.workflow_coding_review import cr_reviewer
     importlib.reload(cr_reviewer)
 
-    # Cria arquivos APÓS o reload (init_workspace pode resetar o diretório)
     coder_ws = Path(cr_reviewer._CODER_WS)
     coder_ws.mkdir(parents=True, exist_ok=True)
     (coder_ws / "app").mkdir(exist_ok=True)
@@ -91,23 +91,6 @@ def test_review_analyzer_instruction_provider_inclui_arquivos_descobertos(tmp_pa
         rendered = instr
 
     assert "- app/main.py" in rendered
-
-
-def test_review_persister_instruction_referencia_analysis_e_anti_narracao(tmp_path, monkeypatch):
-    """Persister.instruction referencia {review_analysis} e tem texto anti-narração."""
-    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
-
-    import importlib
-    from src.agents.workflow_coding_review import cr_reviewer
-    importlib.reload(cr_reviewer)
-
-    instr = cr_reviewer._persister.instruction
-    # Persister.instruction é string estática com placeholder {review_analysis}
-    assert isinstance(instr, str)
-    assert "{review_analysis}" in instr
-    # Anti-narração explícita
-    assert "FAÇA a function call real" in instr or "FAÇA a function call" in instr
-    assert "tool_salvar_relatorio" in instr
 
 
 def test_review_analyzer_tool_ler_arquivo_esta_bound_ao_coder_ws(tmp_path, monkeypatch):
@@ -131,31 +114,65 @@ def test_review_analyzer_tool_ler_arquivo_esta_bound_ao_coder_ws(tmp_path, monke
     assert not result.startswith("Erro:")
 
 
-def test_reviewer_e_sequential_com_2_subagentes(tmp_path, monkeypatch):
-    """_reviewer é SequentialAgent com 2 sub_agents: analyzer primeiro, persister depois."""
-    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
-
-    import importlib
-    from google.adk.agents import SequentialAgent
-    from src.agents.workflow_coding_review import cr_reviewer
-    importlib.reload(cr_reviewer)
-
-    assert isinstance(cr_reviewer.agent, SequentialAgent)
-    assert cr_reviewer.agent.name == "cr_review_agent"
-    assert len(cr_reviewer.agent.sub_agents) == 2
-    assert cr_reviewer.agent.sub_agents[0] is cr_reviewer._analyzer
-    assert cr_reviewer.agent.sub_agents[1] is cr_reviewer._persister
-
-
-def test_review_persister_so_tem_tool_salvar_relatorio(tmp_path, monkeypatch):
-    """Persister tem exatamente 1 tool e ela é tool_salvar_relatorio."""
+def test_analyzer_tem_after_agent_callback(tmp_path, monkeypatch):
+    """_analyzer.after_agent_callback está configurado com _persist_review."""
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
 
     import importlib
     from src.agents.workflow_coding_review import cr_reviewer
     importlib.reload(cr_reviewer)
 
-    tools = cr_reviewer._persister.tools
-    assert len(tools) == 1
-    tool_name = tools[0].func.__name__
-    assert "salvar_relatorio" in tool_name
+    assert cr_reviewer._analyzer.after_agent_callback is cr_reviewer._persist_review
+
+
+def test_agent_e_alias_do_analyzer(tmp_path, monkeypatch):
+    """agent é alias direto de _analyzer — sem LlmAgent intermediário para o save."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+
+    import importlib
+    from src.agents.workflow_coding_review import cr_reviewer
+    importlib.reload(cr_reviewer)
+
+    assert cr_reviewer.agent is cr_reviewer._analyzer
+
+
+def test_persist_review_cria_arquivo_no_review_ws(tmp_path, monkeypatch):
+    """_persist_review escreve verificacao_revisao.md no workspace do reviewer."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+
+    import importlib
+    from src.agents.workflow_coding_review import cr_reviewer
+    importlib.reload(cr_reviewer)
+
+    review_ws = Path(cr_reviewer._REVIEW_WS)
+    review_ws.mkdir(parents=True, exist_ok=True)
+
+    class _FakeCallbackContext:
+        state = {"review_analysis": "## Status: APROVADO\n\n## Resumo\nTudo ok."}
+
+    cr_reviewer._persist_review(_FakeCallbackContext())
+
+    relatorio = review_ws / "verificacao_revisao.md"
+    assert relatorio.exists(), "Relatório não foi criado no workspace do reviewer"
+    content = relatorio.read_text(encoding="utf-8")
+    assert "APROVADO" in content
+
+
+def test_persist_review_nao_cria_arquivo_se_analysis_vazia(tmp_path, monkeypatch):
+    """_persist_review não cria arquivo quando review_analysis está ausente ou vazio."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+
+    import importlib
+    from src.agents.workflow_coding_review import cr_reviewer
+    importlib.reload(cr_reviewer)
+
+    review_ws = Path(cr_reviewer._REVIEW_WS)
+    review_ws.mkdir(parents=True, exist_ok=True)
+
+    class _FakeCallbackContext:
+        state = {}  # sem review_analysis
+
+    cr_reviewer._persist_review(_FakeCallbackContext())
+
+    relatorio = review_ws / "verificacao_revisao.md"
+    assert not relatorio.exists(), "Não deveria criar arquivo com analysis vazia"

--- a/adk/tests/unit/test_review_agent_persistence.py
+++ b/adk/tests/unit/test_review_agent_persistence.py
@@ -159,7 +159,7 @@ def test_persist_review_cria_arquivo_no_review_ws(tmp_path, monkeypatch):
 
 
 def test_persist_review_nao_cria_arquivo_se_analysis_vazia(tmp_path, monkeypatch):
-    """_persist_review não cria arquivo quando review_analysis está ausente ou vazio."""
+    """_persist_review não cria arquivo quando review_analysis está ausente ou só whitespace."""
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
 
     import importlib
@@ -169,13 +169,18 @@ def test_persist_review_nao_cria_arquivo_se_analysis_vazia(tmp_path, monkeypatch
     review_ws = Path(cr_reviewer._REVIEW_WS)
     review_ws.mkdir(parents=True, exist_ok=True)
 
-    class _FakeCallbackContext:
-        state = {}  # sem review_analysis
-
-    cr_reviewer._persist_review(_FakeCallbackContext())
-
     relatorio = review_ws / "verificacao_revisao.md"
-    assert not relatorio.exists(), "Não deveria criar arquivo com analysis vazia"
+
+    for state in [
+        {},           # key ausente
+        {"review_analysis": None},   # None explícito
+        {"review_analysis": "   \n"},  # só whitespace
+    ]:
+        class _FakeCtx:
+            pass
+        _FakeCtx.state = state
+        cr_reviewer._persist_review(_FakeCtx())
+        assert not relatorio.exists(), f"Não deveria criar arquivo para state={state}"
 
 
 def test_adk_runner_dispara_after_agent_callback(tmp_path, monkeypatch):

--- a/adk/tests/unit/test_review_agent_persistence.py
+++ b/adk/tests/unit/test_review_agent_persistence.py
@@ -215,6 +215,7 @@ def test_adk_runner_dispara_after_agent_callback(tmp_path, monkeypatch):
             )
         )
 
+    _original_cb = cr_reviewer._analyzer.before_model_callback
     cr_reviewer._analyzer.before_model_callback = _stub_llm
     try:
         session_svc = InMemorySessionService()
@@ -232,7 +233,7 @@ def test_adk_runner_dispara_after_agent_callback(tmp_path, monkeypatch):
             ),
         ))
     finally:
-        cr_reviewer._analyzer.before_model_callback = None
+        cr_reviewer._analyzer.before_model_callback = _original_cb
 
     relatorio = review_ws / "verificacao_revisao.md"
     assert relatorio.exists(), (

--- a/adk/tests/unit/test_review_agent_persistence.py
+++ b/adk/tests/unit/test_review_agent_persistence.py
@@ -201,7 +201,7 @@ def test_adk_runner_dispara_after_agent_callback(tmp_path, monkeypatch):
 
     from google.adk.models.llm_response import LlmResponse
     from google.adk.runners import Runner
-    from google.adk.sessions import InMemorySessionService
+    from google.adk.sessions.in_memory_session_service import InMemorySessionService
     from google.genai import types as genai_types
 
     fake_analysis = "## Status: APROVADO\n\n## Issues\nNenhum.\n\n## Resumo\nCodigo ok."

--- a/adk/tests/unit/test_review_agent_persistence.py
+++ b/adk/tests/unit/test_review_agent_persistence.py
@@ -229,7 +229,8 @@ def test_adk_runner_dispara_after_agent_callback(tmp_path, monkeypatch):
             user_id="test_user",
             session_id="test_session",
             new_message=genai_types.Content(
-                parts=[genai_types.Part(text="revisar")]
+                role="user",
+                parts=[genai_types.Part(text="revisar")],
             ),
         ))
     finally:

--- a/adk/tests/unit/test_review_agent_persistence.py
+++ b/adk/tests/unit/test_review_agent_persistence.py
@@ -206,7 +206,7 @@ def test_adk_runner_dispara_after_agent_callback(tmp_path, monkeypatch):
 
     fake_analysis = "## Status: APROVADO\n\n## Issues\nNenhum.\n\n## Resumo\nCodigo ok."
 
-    def _stub_llm(_callback_ctx, _llm_request):
+    def _stub_llm(callback_context, llm_request):
         """Bypassa chamada real ao Gemini — retorna análise fake."""
         return LlmResponse(
             content=genai_types.Content(


### PR DESCRIPTION
## Problema

O pipeline de revisão (`workflow_coding_review`) usava um segundo `LlmAgent` (`_review_persister`) cuja única função era persistir o relatório em disco. Isso introduzia risco de **modo narrador**: o LLM descrevia a chamada da tool em linguagem natural em vez de executá-la, resultando em relatório não salvo.

## Solução

Substituí `_review_persister` por `_persist_review`, um `after_agent_callback` executado em Python puro pelo runtime do ADK imediatamente após `_review_analyzer` terminar:

- Zero participação do LLM no passo de escrita em disco
- Persistência determinística: `tool_salvar_relatorio` chamada diretamente em Python
- Pipeline simplificado: `_reviewer` passa a ser alias direto de `_review_analyzer` — sem `SequentialAgent` intermediário

## Atualizações em relação ao PR #283

Branch rebased na develop atual (15 commits, nenhum conflito nos arquivos alterados). Dois bugs identificados e corrigidos durante a atualização:

- `_discover_coder_files`: usa `.as_posix()` em vez de `str(path)` — garante separadores POSIX no prompt independente de plataforma
- `test_adk_runner_dispara_after_agent_callback`: corrige nomes de parâmetros do stub LLM — o ADK chama `before_model_callback` com keyword arguments, o que causava `TypeError` silencioso e impedia o `after_agent_callback` de disparar (10 testes passando)

## Arquivos alterados

- `adk/src/agents/workflow_coding_review/cr_reviewer.py` — remove `_persister` LlmAgent, adiciona `_persist_review` em `after_agent_callback` do `_analyzer`, guard `TYPE_CHECKING` no import de `CallbackContext`, validação do retorno de `tool_salvar_relatorio`
- `adk/tests/unit/test_review_agent_persistence.py` — testes para o novo padrão de callback + teste de integração com ADK Runner (sem chamada real ao Gemini)
