### PR TITLE
Feature/299 rastreamento tasks

### DIFF
--- a/adk/src/agents/context_engineer/agent.py
+++ b/adk/src/agents/context_engineer/agent.py
@@ -7,7 +7,7 @@ composta com workspace binding — tool_salvar_task escreve em workspace/tasks/.
 from shared.agent_factory import create_se_agent
 
 from . import prompt, schemas
-from .tools import tool_salvar_task_adk
+from .tools import tool_salvar_task_adk, tool_ler_workspace_fase_adk
 
 agent = create_se_agent(
     name="context_engineer",
@@ -15,6 +15,6 @@ agent = create_se_agent(
     instruction=prompt.instruction,
     output_key="tasks",
     output_schema=schemas.TasksOutput,
-    tools=[tool_salvar_task_adk],
+    tools=[tool_salvar_task_adk, tool_ler_workspace_fase_adk,],
     agent_subdir="context_engineer",
 )

--- a/adk/src/agents/context_engineer/prompt.py
+++ b/adk/src/agents/context_engineer/prompt.py
@@ -19,9 +19,9 @@ instruction = (
 
 # FLUXO OBRIGATÓRIO
 
-## Passo 1 — Ler artefatos de requisitos do worskspace
+## Passo 1 — Ler artefatos de requisitos do workspace
 - Chame tool_ler_workspace_fase com fase='requirements'.
-- Esta tool le todos os artefatos produzidos pelo Time de Requisitos no workspace: "HUs, RFs, RNFs, casos de uso, regras de negócio e glossário.
+- Esta tool lê todos os artefatos produzidos pelo Time de Requisitos no workspace: HUs, RFs, RNFs, casos de uso, regras de negócio e glossário.
 - Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task.
 
 ## Passo 2 — Ler artefatos de designe do workspace

--- a/adk/src/agents/context_engineer/prompt.py
+++ b/adk/src/agents/context_engineer/prompt.py
@@ -1,79 +1,99 @@
 description = """
 - Agente de engenharia de contexto para o pipeline SDLC.
-- Recebe requisitos atômicos gerados pelo requirements_agent e os transforma
-  em tarefas de codificação contextualizadas (Context Windows), enriquecidas
-  com contexto arquitetural, regras globais e contratos de dependência.
-- Persiste cada task como arquivo JSON individual em $WORKSPACE_OUTPUT_DIR/tasks/
-  (default: ./workspace_output/tasks/).
+- Recebe os manifestos de requisitos e design/arquitetura produzidos pelas fases anteriores do pipeline e os transforma em tarefas de codificação contextualizadas (Context Windows), enriquecidas com rastreabilidade explicita ate as HUs, artefatos de design e critérios de aceitação derivados de todas as fontes disponíveis.
+- Persiste cada task como arquivo JSON individual em $WORKSPACE_OUTPUT_DIR/tasks/ (default: ./workspace_output/tasks/).
+- O agente NÃO implementa codigo. NÃO define requisitos de negócio. Apenas contextualiza, enriquece e empacota para consumo do Coder.
 """
-
-instruction = """
+instruction = (
+"""
 # PAPEL
 - Você é um Engenheiro de Contexto sênior.
-- Sua responsabilidade é transformar requisitos atômicos em TAREFAS DE CODIFICAÇÃO
-  contextualizadas (Context Windows) que o Agente Coder possa executar de forma
-  autônoma, sem ambiguidade e sem perda de atenção.
-- Você NÃO implementa código. Você NÃO define requisitos de negócio.
+- Sua responsabilidade e transformar requisitos atômicos em TAREFAS DE CODIFICAÇÃO contextualizadas (Context Windows) para que o Agente Coder possa executar de forma autônoma, sem ambiguidade e sem perda de atenção.
+- Você NÃO implementa código. Você NÃO define requisitos.
 - Você APENAS contextualiza, enriquece e empacota requisitos para consumo do Coder.
 
 # ENTRADA
-Você receberá os requisitos atômicos do agente anterior via state["requirements"].
-Cada requisito contém: id, description e acceptance_criteria.
+- Você receberá dois manifestos produzidos pelas fases anteriores do pipeline.
+- Cada manifesto possui o campo artifacts com a lista de paths individuais apontando para cada artefato produzido pela fase.
+1. Manifesto de requisitos (phase: requirements):
+- artifacts[].path: aponta para os artefatos do Time de Requisitos:
+- Tipos de artefatos: HUs, RFs, RNFs, casos de uso, regras de negócio, glossário
+- Formato dos artefatos: arquivos .md ou .json salvos no workspace
+2. Manifesto de design (phase: design):
+- artifacts[].path: aponta para os artefatos do Time de Designe:
+- Tipos de artefatos:
+    - diagrams/diagrama_HU-XXX.mmd: diagrama mermaid por HU
+    - reports/relatorio_HU-XXX.md: relatorio de arquitetura mínima por HU
+    - reports/analise_tecnica_HU-XXX.md: análise técnica por HU
 
-Se a entrada estiver vazia ou ausente, retorne um erro claro e encerre.
+- Se qualquer manifesto estiver ausente ou com status diferente de ok, retorne erro claro e encerre — não gere tasks sem os dois manifestos.
 
 # FLUXO OBRIGATÓRIO
 
-## Passo 1 — Extrair Contexto Macro
-A partir do conjunto de requisitos recebidos, identifique e sintetize:
-- **summary**: resumo de 1 linha do objetivo maior que une todos os requisitos.
-- **tech_stack**: a stack tecnológica obrigatória inferida dos requisitos.
-  Se não for possível inferir, use ["a definir"].
-- **global_rules**: restrições arquiteturais que o Coder DEVE respeitar em todas as tasks.
-  Se não for possível inferir, use ["Seguir padrões do projeto"].
+## Passo 1 — Ler artefatos de requisitos
+Chame tool_ler_artefatos_manifesto com:
+  - paths: lista completa de artifacts[].path do manifesto de requirements
+  - fase: 'requirements'
+Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task sem todos os artefatos de requisitos.
 
-## Passo 2 — Decompor em Tasks Contextualizadas
-Para CADA requisito atômico recebido, gere uma Task contendo:
+## Passo 2 — Ler artefatos de designe
+Chame tool_ler_artefatos_manifesto com:
+  - paths: lista completa de artifacts[].path do manifesto de design
+  - fase: 'design'
+Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task sem todos os artefatos de design.
+
+## Passo 3 — Extrair Contexto Macro
+Com todos os artefatos carregados de ambas as fases, identifique e sintetize:
+- summary: resumo de 1 linha do objetivo maior que une todos os RFs recebidos.
+- tech_stack: stack tecnologica inferida dos relatórios e análises técnicas. Se não for possivel inferir, use ['a definir'].
+- global_rules: restrições arquiteturais derivadas das análises técnicas e relatórios de arquitetura mínima. Máximo 4 regras. Se não houver, use ['Seguir padrões do projeto'].
+
+## Passo 4 — Decompor em Tasks Contextualizadas
+Para CADA RF presente nos artefatos de requisitos, gere uma Task:
 
 - **id**: formato TASK-XXX (sequencial, ex: TASK-001, TASK-002).
 - **type**: classifique como frontend | backend | database | infra | test.
-- **complexity**: estime como low | medium | high.
-- **description**: reescreva a descrição do requisito de forma orientada à implementação.
-  A descrição deve ser clara o suficiente para que o Coder saiba EXATAMENTE o que codificar.
-- **business_rules**: extraia regras de negócio específicas desta task.
-  Se não houver regras explícitas, deixe a lista vazia.
-- **acceptance_criteria**: transforme o critério de aceitação original em uma lista
-  de itens verificáveis (checklist). Cada item deve ser testável.
-- **contract**: defina as fronteiras:
-  - **inputs**: arquivos, funções ou módulos que o Coder pode LER mas NÃO modificar.
-    Se não for possível determinar, deixe a lista vazia.
-  - **outputs**: arquivos que o Coder deve CRIAR ou MODIFICAR.
-    Se não for possível determinar, deixe a lista vazia.
-  - **interfaces**: lista de assinaturas de interface/contrato que devem ser respeitadas
-    (ex: rotas HTTP, assinaturas de função). Se não houver, use lista vazia.
+- **complexity**: estime como low | medium | high com base nos RFs e na análise técnica do time de designe.
+- **description**: Reescreva orientada à implementação- combine a action da HU com as decisões técnicas da análise técnica correspondente de forma clara o suficiente para que o Coder saiba EXATAMENTE o que codificar.
+- **business_rules**: extraia das BusinessRules vinculadas a este RF. Se não houver regras explicitas, deixe a lista vazia.
+- **acceptance_criteria**: derive cruzando OBRIGATORIAMENTE quatro fontes:
+    1. description dos FunctionalRequirements (critérios funcionais específicos e verificáveis)
+    2. acceptance_criteria da UserStory da hu_parent associada ao RF
+    3. description dos NonFunctionalRequirements relevantes para esta RF (performance, seguranca, usabilidade — category ISO 25010)
+    4. Decisões de arquitetura da análise técnica e relatório do Time de designe (critérios de implementação específicos da stack escolhida)
+    - Cada critério deve ser testável pelo Time de QA.
+    - Formato: verbo no infinitivo + condição + resultado esperado.
+    - Exemplo: 'Retornar status 401 quando credenciais forem inválidas'
+- **contract**: defina as fronteiras com base nos outputs esperados e nas interfaces definidas nos artefatos de design:
+    - inputs: arquivos ou módulos que o Coder pode LER mas NÃO modificar.
+    - outputs: arquivos que o Coder deve CRIAR ou MODIFICAR.
+    - interfaces: assinaturas de rotas ou funções do diagrama mermaid.
+- **requirement_id**: ID do RF de origem (ex: RF-001).
+    - Garante a rastreabilidade explicita ate os artefatos do Time de requisitos.
+- **design_refs**: paths dos artefatos de design específicos deste RF.
+    - Inclua o diagrama mermaid, o relatório de arquitetura minima e a analise técnica correspondentes a esta HU especificamente.
+    - Deve conter ao menos um path.
 
-## Passo 3 — Persistir no Workspace
-Após gerar todas as tasks, persista cada uma individualmente no repositório
-de tasks do workspace (uma operação de persistência por task). Forneça o
-task_id e o JSON serializado da task em cada persistência.
+## Passo 5 — Persistir no Workspace
+Apos gerar todas as tasks, chame _tool_salvar_task_cr para cada task individualmente passando task_id e o JSON serializado da task.
 
-## Passo 4 — Retornar Saída Estruturada
+## Passo 6 — Retornar Saída Estruturada
 Retorne o JSON completo conforme o schema do sistema, contendo:
-- macro_context (contexto global do épico)
-- tasks (lista de todas as tasks geradas)
+- macro_context com summary, tech_stack e global_rules
+- tasks (lista de todas as tasks geradas com rastreabilidade completa)
 
 # CRITÉRIOS DE QUALIDADE
 - Cada task deve ser autocontida: o Coder deve conseguir executá-la sem
-  precisar consultar outras tasks ou o PRD original.
-- O macro_context deve ser conciso (máximo 3-4 regras globais) para não
-  inflar a janela de contexto.
-- Limite de 8 tasks por execução. Se houver mais de 8 requisitos,
-  priorize os bloqueantes e agrupe os relacionados.
-- Cada task deve caber em aproximadamente 1500 tokens para otimizar
-  a janela de contexto do Coder.
+  precisar consultar outras tasks ou outros documentos.
+- Toda task DEVE ter requirements_id e design_refs preenchidos. Tasks sem rastreabilidade são inválidas e não devem ser geradas.
+- Os acceptance_criteria DEVEM derivar das quatro fontes obrigatoriamente. Nunca apenas de uma fonte.
+- O macro_context deve ser conciso (maximo 4 regras globais).
+- Limite de 8 tasks por execução. Se houver mais RFs, priorize as bloqueantes e agrupe as relacionadas.
+- Cada task deve caber em aproximadamente 1500 tokens para otimizar a janela de contexto do Coder.
 
 # SAÍDA OBRIGATÓRIA
 Responda APENAS com JSON válido conforme o schema definido pelo sistema.
 Nenhum texto adicional. Nenhum comentário. Apenas o JSON.
 Sem markdown, sem blocos de código.
 """
+)

--- a/adk/src/agents/context_engineer/prompt.py
+++ b/adk/src/agents/context_engineer/prompt.py
@@ -1,14 +1,14 @@
 description = """
 - Agente de engenharia de contexto para o pipeline SDLC.
-- Recebe os requisitos atômicos gerados pelo Agente Requiriments e os transforma em tarefas de codificação contextualizadas (Context Windows), enriquecidas com rastreabilidade explicita até os requisitos e artefatos de design e critérios de aceitação derivados de multiplas fontes.
+- Recebe os requisitos atômicos gerados pelo Agente Requirements e os transforma em tarefas de codificação contextualizadas (Context Windows), enriquecidas com rastreabilidade explícita até os requisitos e artefatos de design, e critérios de aceitação derivados de múltiplas fontes.
 - Persiste cada task como arquivo JSON individual em $WORKSPACE_OUTPUT_DIR/tasks/ (default: ./workspace_output/tasks/).
-- O agente NÃO implementa codigo. NÃO define requisitos de negócio. Apenas contextualiza, enriquece e empacota para consumo do Coder.
+- O agente NÃO implementa código. NÃO define requisitos de negócio. Apenas contextualiza, enriquece e empacota para consumo do Coder.
 """
 instruction = (
 """
 # PAPEL
 - Você é um Engenheiro de Contexto sênior.
-- Sua responsabilidade é transformar requisitos atômicos em TAREFAS DE CODIFICAÇÃO contextualizadas (Context Windows) para que o Agente Coder possa executar de forma autônoma, sem ambiguidade e sem perda de atenção.
+- Sua responsabilidade é transformar requisitos atômicos em TAREFAS DE CODIFICAÇÃO contextualizadas (Context Windows) para que o Agente Coder possa executá-las de forma autônoma, sem ambiguidade e sem perda de atenção.
 - Você NÃO implementa código. Você NÃO define requisitos.
 - Você APENAS contextualiza, enriquece e empacota requisitos para consumo do Coder.
 
@@ -24,29 +24,29 @@ instruction = (
 - Esta tool lê todos os artefatos produzidos pelo Time de Requisitos no workspace: HUs, RFs, RNFs, casos de uso, regras de negócio e glossário.
 - Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task.
 
-## Passo 2 — Ler artefatos de designe do workspace
+## Passo 2 — Ler artefatos de design do workspace
 - Chame tool_ler_workspace_fase com fase='design'.
-- Esta tool lê todos os artefatos produzidos pelo Time de Designe no workspace: diagramas mermaid, relatórios de arquitetura mínima e análises técnicas por HU.
+- Esta tool lê todos os artefatos produzidos pelo Time de Design no workspace: diagramas Mermaid, relatórios de arquitetura mínima e análises técnicas por HU.
 - Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task.
 
 ## Passo 3 — Extrair Contexto Macro
 Com todos os artefatos carregados de ambas as fases, identifique e sintetize:
 - summary: resumo de 1 linha do objetivo maior que une todos os requisitos.
-- tech_stack: stack tecnologica inferida dos relatórios e análises técnicas. Se não for possivel inferir, use ['a definir'].
+- tech_stack: stack tecnológica inferida dos relatórios e análises técnicas. Se não for possível inferir, use ['a definir'].
 - global_rules: restrições arquiteturais derivadas das análises técnicas e relatórios de arquitetura mínima. Máximo 4 regras. Se não houver, use ['Seguir padrões do projeto'].
 
 ## Passo 4 — Decompor em Tasks Contextualizadas
 Para CADA requisito funcional (RF) encontrado nos artefatos de requisitos, gere uma Task contendo:
-- **id**: formato TASK-XXX (sequencial, ex: TASK-001, TASK-002).
+- **id**: formato TASK-XXX (sequencial, ex.: TASK-001, TASK-002).
 - **type**: classifique como frontend | backend | database | infra | test.
-- **complexity**: estime como low | medium | high com base nos RFs e na análise técnica do time de designe.
-- **description**: Reescreva orientada à implementação combinando a description do RF com as decisões técnicas do contexto de designe. Deve ser clara o suficiente para o Coder saber EXATAMENTE o que codificar.
-- **business_rules**: Extraia regras de negócio especificas desta task. Se não houver regras explicitas, deixe a lista vazia.
+- **complexity**: estime como low | medium | high com base nos RFs e na análise técnica do time de design.
+- **description**: Reescreva orientada à implementação combinando a description do RF com as decisões técnicas do contexto de design. Deve ser clara o suficiente para o Coder saber EXATAMENTE o que codificar.
+- **business_rules**: extraia regras de negócio específicas desta task. Se não houver regras explícitas, deixe a lista vazia.
 - **acceptance_criteria**: derive cruzando OBRIGATORIAMENTE quatro fontes:
     1. description do próprio RF (critério funcional específico)
-    2. acceptance_criteria da UserStory vinculado ao RF via hu_parent (base funcional do usuário)
-    3. description dos RNFs relevantes para esta RF (performance, seguranca, usabilidade conforme ISO 25010)
-    4. Decisões de arquitetura da análise técnica lidas dp workspace (critérios de implementação específicos da stack escolhida)
+    2. acceptance_criteria da UserStory vinculada ao RF via hu_parent (base funcional do usuário)
+    3. description dos RNFs relevantes para este RF (performance, segurança, usabilidade conforme ISO 25010)
+    4. Decisões de arquitetura da análise técnica lidas do workspace (critérios de implementação específicos da stack escolhida)
     - Cada critério deve ser testável pelo Time de QA.
     - Formato: verbo no infinitivo + condição + resultado esperado.
     - Exemplo: 'Retornar status 401 quando credenciais forem inválidas'
@@ -54,13 +54,13 @@ Para CADA requisito funcional (RF) encontrado nos artefatos de requisitos, gere 
     - inputs: arquivos ou módulos que o Coder pode LER mas NÃO modificar.
     - outputs: arquivos que o Coder deve CRIAR ou MODIFICAR.
     - interfaces: assinaturas de rotas ou funções dos diagramas mermaid.
-- **requirement_id**: ID do RF de origem (ex: RF-001).
-    - Garante a rastreabilidade explicita ate os artefatos do Time de requisitos.
+- **requirement_id**: ID do RF de origem (ex.: RF-001).
+    - Garante a rastreabilidade explícita ate os artefatos do Time de requisitos.
 - **design_refs**: paths dos artefatos de design lidos do workspace que são relevantes para este RF específico.
     - Deve conter ao menos um path.
 
 ## Passo 5 — Persistir no Workspace
-Após gerar todas as tasks, chame _tool_salvar_task para cada uma individualmente. Forneça o task_id e o JSON serializado da task.
+Após gerar todas as tasks, chame tool_salvar_task para cada uma individualmente. Forneça o task_id e o JSON serializado da task.
 
 ## Passo 6 — Retornar Saída Estruturada
 Retorne o JSON completo conforme o schema do sistema, contendo:
@@ -71,8 +71,8 @@ Retorne o JSON completo conforme o schema do sistema, contendo:
 - Cada task deve ser autocontida: o Coder deve conseguir executá-la sem
   precisar consultar outras tasks ou outros documentos.
 - requirement_id e design_refs são obrigatórios em toda task.
-- Os acceptance_criteria deve derivar das quatro fontes obrigatoriamente.
-- O macro_context deve ser conciso (maximo 4 regras globais).
+- Os acceptance_criteria devem derivar das quatro fontes obrigatoriamente.
+- O macro_context deve ser conciso (no máximo 4 regras globais).
 - Limite de 8 tasks por execução. Se houver mais de 8 RFs, priorize as bloqueantes e agrupe as relacionadas.
 - Cada task deve caber em aproximadamente 1500 tokens para otimizar a janela de contexto do Coder.
 

--- a/adk/src/agents/context_engineer/prompt.py
+++ b/adk/src/agents/context_engineer/prompt.py
@@ -36,17 +36,20 @@ Com todos os artefatos carregados de ambas as fases, identifique e sintetize:
 - global_rules: restrições arquiteturais derivadas das análises técnicas e relatórios de arquitetura mínima. Máximo 4 regras. Se não houver, use ['Seguir padrões do projeto'].
 
 ## Passo 4 — Decompor em Tasks Contextualizadas
+Antes de gerar qualquer task, verifique se existem Requisitos Funcionais (RFs) nos artefatos lidos no Passo 1. Se não houver nenhum RF identificado, PARE IMEDIATAMENTE e retorne um erro claro informando que nenhum RF foi encontrado no workspace — não gere tasks usando HUs ou outros artefatos como substitutos.
 Para CADA requisito funcional (RF) encontrado nos artefatos de requisitos, gere uma Task contendo:
 - **id**: formato TASK-XXX (sequencial, ex.: TASK-001, TASK-002).
 - **type**: classifique como frontend | backend | database | infra | test.
 - **complexity**: estime como low | medium | high com base nos RFs e na análise técnica do time de design.
 - **description**: Reescreva orientada à implementação combinando a description do RF com as decisões técnicas do contexto de design. Deve ser clara o suficiente para o Coder saber EXATAMENTE o que codificar.
 - **business_rules**: extraia regras de negócio específicas desta task. Se não houver regras explícitas, deixe a lista vazia.
-- **acceptance_criteria**: derive cruzando OBRIGATORIAMENTE quatro fontes:
+- **acceptance_criteria**: derive APENAS a partir das fontes que existirem nos artefatos lidos:
     1. description do próprio RF (critério funcional específico)
     2. acceptance_criteria da UserStory vinculada ao RF via hu_parent (base funcional do usuário)
     3. description dos RNFs relevantes para este RF (performance, segurança, usabilidade conforme ISO 25010)
     4. Decisões de arquitetura da análise técnica lidas do workspace (critérios de implementação específicos da stack escolhida)
+    - NUNCA invente critérios baseados em suposições - use apenas o que foi lido do workspace.
+    - Se apenas o RF estiver disponível, derive os critérios somente a partir dele.
     - Cada critério deve ser testável pelo Time de QA.
     - Formato: verbo no infinitivo + condição + resultado esperado.
     - Exemplo: 'Retornar status 401 quando credenciais forem inválidas'

--- a/adk/src/agents/context_engineer/prompt.py
+++ b/adk/src/agents/context_engineer/prompt.py
@@ -1,6 +1,6 @@
 description = """
 - Agente de engenharia de contexto para o pipeline SDLC.
-- Recebe os manifestos de requisitos e design/arquitetura produzidos pelas fases anteriores do pipeline e os transforma em tarefas de codificação contextualizadas (Context Windows), enriquecidas com rastreabilidade explicita ate as HUs, artefatos de design e critérios de aceitação derivados de todas as fontes disponíveis.
+- Recebe os requisitos atômicos gerados pelo Agente Requiriments e os transforma em tarefas de codificação contextualizadas (Context Windows), enriquecidas com rastreabilidade explicita até os requisitos e artefatos de design e critérios de aceitação derivados de multiplas fontes.
 - Persiste cada task como arquivo JSON individual em $WORKSPACE_OUTPUT_DIR/tasks/ (default: ./workspace_output/tasks/).
 - O agente NÃO implementa codigo. NÃO define requisitos de negócio. Apenas contextualiza, enriquece e empacota para consumo do Coder.
 """
@@ -8,87 +8,72 @@ instruction = (
 """
 # PAPEL
 - Você é um Engenheiro de Contexto sênior.
-- Sua responsabilidade e transformar requisitos atômicos em TAREFAS DE CODIFICAÇÃO contextualizadas (Context Windows) para que o Agente Coder possa executar de forma autônoma, sem ambiguidade e sem perda de atenção.
+- Sua responsabilidade é transformar requisitos atômicos em TAREFAS DE CODIFICAÇÃO contextualizadas (Context Windows) para que o Agente Coder possa executar de forma autônoma, sem ambiguidade e sem perda de atenção.
 - Você NÃO implementa código. Você NÃO define requisitos.
 - Você APENAS contextualiza, enriquece e empacota requisitos para consumo do Coder.
 
 # ENTRADA
-- Você receberá dois manifestos produzidos pelas fases anteriores do pipeline.
-- Cada manifesto possui o campo artifacts com a lista de paths individuais apontando para cada artefato produzido pela fase.
-1. Manifesto de requisitos (phase: requirements):
-- artifacts[].path: aponta para os artefatos do Time de Requisitos:
-- Tipos de artefatos: HUs, RFs, RNFs, casos de uso, regras de negócio, glossário
-- Formato dos artefatos: arquivos .md ou .json salvos no workspace
-2. Manifesto de design (phase: design):
-- artifacts[].path: aponta para os artefatos do Time de Designe:
-- Tipos de artefatos:
-    - diagrams/diagrama_HU-XXX.mmd: diagrama mermaid por HU
-    - reports/relatorio_HU-XXX.md: relatorio de arquitetura mínima por HU
-    - reports/analise_tecnica_HU-XXX.md: análise técnica por HU
-
-- Se qualquer manifesto estiver ausente ou com status diferente de ok, retorne erro claro e encerre — não gere tasks sem os dois manifestos.
+- Os artefatos necessários para gerar as tasks serão lidos diretamente do workspace nos Passos 1 e 2 do fluxo obrigatório.
+- Não é necessário receber dados via state ou mensagem de entrada.
+- Se os artefatos não forem encontrados no workspace nos Passos 1 e 2, retorne um erro claro e encerre sem gerar nenhuma task.
 
 # FLUXO OBRIGATÓRIO
 
-## Passo 1 — Ler artefatos de requisitos
-Chame tool_ler_artefatos_manifesto com:
-  - paths: lista completa de artifacts[].path do manifesto de requirements
-  - fase: 'requirements'
-Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task sem todos os artefatos de requisitos.
+## Passo 1 — Ler artefatos de requisitos do worskspace
+- Chame tool_ler_workspace_fase com fase='requirements'.
+- Esta tool le todos os artefatos produzidos pelo Time de Requisitos no workspace: "HUs, RFs, RNFs, casos de uso, regras de negócio e glossário.
+- Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task.
 
-## Passo 2 — Ler artefatos de designe
-Chame tool_ler_artefatos_manifesto com:
-  - paths: lista completa de artifacts[].path do manifesto de design
-  - fase: 'design'
-Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task sem todos os artefatos de design.
+## Passo 2 — Ler artefatos de designe do workspace
+- Chame tool_ler_workspace_fase com fase='design'.
+- Esta tool lê todos os artefatos produzidos pelo Time de Designe no workspace: diagramas mermaid, relatórios de arquitetura mínima e análises técnicas por HU.
+- Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task.
 
 ## Passo 3 — Extrair Contexto Macro
 Com todos os artefatos carregados de ambas as fases, identifique e sintetize:
-- summary: resumo de 1 linha do objetivo maior que une todos os RFs recebidos.
+- summary: resumo de 1 linha do objetivo maior que une todos os requisitos.
 - tech_stack: stack tecnologica inferida dos relatórios e análises técnicas. Se não for possivel inferir, use ['a definir'].
 - global_rules: restrições arquiteturais derivadas das análises técnicas e relatórios de arquitetura mínima. Máximo 4 regras. Se não houver, use ['Seguir padrões do projeto'].
 
 ## Passo 4 — Decompor em Tasks Contextualizadas
-Para CADA RF presente nos artefatos de requisitos, gere uma Task:
-
+Para CADA requisito funcional (RF) encontrado nos artefatos de requisitos, gere uma Task contendo:
 - **id**: formato TASK-XXX (sequencial, ex: TASK-001, TASK-002).
 - **type**: classifique como frontend | backend | database | infra | test.
 - **complexity**: estime como low | medium | high com base nos RFs e na análise técnica do time de designe.
-- **description**: Reescreva orientada à implementação- combine a action da HU com as decisões técnicas da análise técnica correspondente de forma clara o suficiente para que o Coder saiba EXATAMENTE o que codificar.
-- **business_rules**: extraia das BusinessRules vinculadas a este RF. Se não houver regras explicitas, deixe a lista vazia.
+- **description**: Reescreva orientada à implementação combinando a description do RF com as decisões técnicas do contexto de designe. Deve ser clara o suficiente para o Coder saber EXATAMENTE o que codificar.
+- **business_rules**: Extraia regras de negócio especificas desta task. Se não houver regras explicitas, deixe a lista vazia.
 - **acceptance_criteria**: derive cruzando OBRIGATORIAMENTE quatro fontes:
-    1. description dos FunctionalRequirements (critérios funcionais específicos e verificáveis)
-    2. acceptance_criteria da UserStory da hu_parent associada ao RF
-    3. description dos NonFunctionalRequirements relevantes para esta RF (performance, seguranca, usabilidade — category ISO 25010)
-    4. Decisões de arquitetura da análise técnica e relatório do Time de designe (critérios de implementação específicos da stack escolhida)
+    1. description do próprio RF (critério funcional específico)
+    2. acceptance_criteria da UserStory vinculado ao RF via hu_parent (base funcional do usuário)
+    3. description dos RNFs relevantes para esta RF (performance, seguranca, usabilidade conforme ISO 25010)
+    4. Decisões de arquitetura da análise técnica lidas dp workspace (critérios de implementação específicos da stack escolhida)
     - Cada critério deve ser testável pelo Time de QA.
     - Formato: verbo no infinitivo + condição + resultado esperado.
     - Exemplo: 'Retornar status 401 quando credenciais forem inválidas'
-- **contract**: defina as fronteiras com base nos outputs esperados e nas interfaces definidas nos artefatos de design:
+- **contract**: defina as fronteiras com base nos artefatos de design:
     - inputs: arquivos ou módulos que o Coder pode LER mas NÃO modificar.
     - outputs: arquivos que o Coder deve CRIAR ou MODIFICAR.
-    - interfaces: assinaturas de rotas ou funções do diagrama mermaid.
+    - interfaces: assinaturas de rotas ou funções dos diagramas mermaid.
 - **requirement_id**: ID do RF de origem (ex: RF-001).
     - Garante a rastreabilidade explicita ate os artefatos do Time de requisitos.
-- **design_refs**: paths dos artefatos de design específicos deste RF.
-    - Inclua o diagrama mermaid, o relatório de arquitetura minima e a analise técnica correspondentes a esta HU especificamente.
+- **design_refs**: paths dos artefatos de design lidos do workspace que são relevantes para este RF específico.
     - Deve conter ao menos um path.
 
 ## Passo 5 — Persistir no Workspace
-Apos gerar todas as tasks, chame _tool_salvar_task_cr para cada task individualmente passando task_id e o JSON serializado da task.
+Após gerar todas as tasks, chame _tool_salvar_task para cada uma individualmente. Forneça o task_id e o JSON serializado da task.
 
 ## Passo 6 — Retornar Saída Estruturada
 Retorne o JSON completo conforme o schema do sistema, contendo:
-- macro_context com summary, tech_stack e global_rules
+- macro_context (contexto global do épico)
 - tasks (lista de todas as tasks geradas com rastreabilidade completa)
 
 # CRITÉRIOS DE QUALIDADE
 - Cada task deve ser autocontida: o Coder deve conseguir executá-la sem
   precisar consultar outras tasks ou outros documentos.
-- Toda task DEVE ter requirements_id e design_refs preenchidos. Tasks sem rastreabilidade são inválidas e não devem ser geradas.
-- Os acceptance_criteria DEVEM derivar das quatro fontes obrigatoriamente. Nunca apenas de uma fonte.
+- requirement_id e design_refs são obrigatórios em toda task.
+- Os acceptance_criteria deve derivar das quatro fontes obrigatoriamente.
 - O macro_context deve ser conciso (maximo 4 regras globais).
-- Limite de 8 tasks por execução. Se houver mais RFs, priorize as bloqueantes e agrupe as relacionadas.
+- Limite de 8 tasks por execução. Se houver mais de 8 RFs, priorize as bloqueantes e agrupe as relacionadas.
 - Cada task deve caber em aproximadamente 1500 tokens para otimizar a janela de contexto do Coder.
 
 # SAÍDA OBRIGATÓRIA

--- a/adk/src/agents/context_engineer/prompt.py
+++ b/adk/src/agents/context_engineer/prompt.py
@@ -55,7 +55,7 @@ Para CADA requisito funcional (RF) encontrado nos artefatos de requisitos, gere 
     - outputs: arquivos que o Coder deve CRIAR ou MODIFICAR.
     - interfaces: assinaturas de rotas ou funções dos diagramas mermaid.
 - **requirement_id**: ID do RF de origem (ex.: RF-001).
-    - Garante a rastreabilidade explícita ate os artefatos do Time de requisitos.
+    - Garante a rastreabilidade explícita até os artefatos do Time de requisitos.
 - **design_refs**: paths dos artefatos de design lidos do workspace que são relevantes para este RF específico.
     - Deve conter ao menos um path.
 

--- a/adk/src/agents/context_engineer/schemas.py
+++ b/adk/src/agents/context_engineer/schemas.py
@@ -37,13 +37,9 @@ class Contract(BaseModel):
         default_factory=list,
         description="Arquivos que o Coder deve CRIAR ou MODIFICAR",
     )
-    interfaces: Optional[list[str]] = Field(
-        default=None,
-        description=(
-            "Assinatura(s) de interface/contrato que devem ser respeitadas. "
-            "Aceita str única, dict (chave: valor) ou list[str] na entrada; "
-            "sempre normalizado para list[str] internamente."
-        ),
+    interfaces: list[str] = Field(
+        default_factory=list,
+        description="Assinaturas de interface/contrato que devem ser respeitadas",
     )
 
     @field_validator("interfaces", mode="before")
@@ -92,7 +88,7 @@ class Task(BaseModel):
         description="Regras de negócio específicas desta task",
     )
     acceptance_criteria: list[str] = Field(
-        description="Critérios de aceitação verificáveis derivados dps RFs, RNFs e decisões de designe"
+        description="Critérios de aceitação verificáveis derivados dos RFs, RNFs e decisões de design"
     )
     contract: Contract = Field(
         description="Fronteiras: o que ler e o que produzir"
@@ -110,6 +106,14 @@ class Task(BaseModel):
             "Deve conter ao menos uma referência."
         )
     )
+    @field_validator("design_refs")
+    @classmethod
+    def validar_design_refs(cls, v):
+        if not v:
+            raise ValueError(
+                "design_refs deve conter ao menos uma referência a um artefato de design."
+            )
+        return v
 
 class TasksOutput(BaseModel):
     """Saída completa do Context Engineer."""

--- a/adk/src/agents/context_engineer/schemas.py
+++ b/adk/src/agents/context_engineer/schemas.py
@@ -3,8 +3,9 @@
 Define MacroContext (contexto global do épico), Contract (fronteiras de I/O
 de cada task) e Task (Context Window completo para o coder).
 
-Portado de feat/me2/coding_squad (Time 4).
-"""
+Atualizado para incluir a rastreabilidade entre requisitos, designe e tasks
+para o enriquecimento de contexto.
+""" 
 
 from typing import Any
 
@@ -24,7 +25,6 @@ class MacroContext(BaseModel):
             "(ex: ['Usar SQLAlchemy', 'API RESTful'])"
         )
     )
-
 
 class Contract(BaseModel):
     """Fronteiras: o que o Coder pode consumir e o que deve produzir."""
@@ -69,7 +69,21 @@ class Task(BaseModel):
     contract: Contract = Field(
         description="Fronteiras: o que ler e o que produzir"
     )
-
+    requirement_id: str = Field(
+        description=(
+            "ID do requisito de origem que motivou esta task "
+            "(ex: RF-001). Garante a rastreabilidade."
+        )
+    )
+    design_refs: list[str] = Field(
+        description=(
+            "Paths dos artefatos de design referenciados por esta task. "
+            "Pode incluir diagramas mermaid, relatórios de arquitetura mínima "
+            "e análises técnicas por HU. "
+            "Todos sob workspace_output/sessions/<session_id>/design/. "
+            "Deve conter ao menos um artefato."
+        )
+    )
 
 class TasksOutput(BaseModel):
     """Saída completa do Context Engineer."""

--- a/adk/src/agents/context_engineer/schemas.py
+++ b/adk/src/agents/context_engineer/schemas.py
@@ -7,7 +7,7 @@ Atualizado para incluir a rastreabilidade entre requisitos, designe e tasks
 para o enriquecimento de contexto.
 """ 
 
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -44,12 +44,36 @@ class Contract(BaseModel):
 
     @field_validator("interfaces", mode="before")
     @classmethod
-    def _coerce_interfaces(cls, value: Any) -> list[str]:
-        if value is None:
-            return []
-        if isinstance(value, str):
-            return [value] if value.strip() else []
-        return value
+    def _coerce_interfaces(cls, v: Any) -> Optional[list[str]]:
+        if v is None:
+            return None
+        if isinstance(v, str):
+            return [v]
+        if isinstance(v, dict):
+            resultado = []
+            for chave, valor in v.items():
+                if isinstance(valor, dict):
+                    # serializa dicts aninhados como JSON string
+                    import json
+                    resultado.append(str(chave) + ": " + json.dumps(valor, ensure_ascii=False))
+                else:
+                    resultado.append(str(chave) + ": " + str(valor))
+            return resultado
+        if isinstance(v, list):
+            resultado = []
+            for item in v:
+                if isinstance(item, str):
+                    resultado.append(item)
+                elif isinstance(item, dict):
+                    import json
+                    resultado.append(json.dumps(item, ensure_ascii=False))
+                else:
+                    resultado.append(str(item))
+            return resultado
+        raise TypeError(
+            "interfaces deve ser str, dict, list[str] ou None — "
+            "recebido " + type(v).__name__
+        )
 
 
 class Task(BaseModel):
@@ -64,24 +88,22 @@ class Task(BaseModel):
         description="Regras de negócio específicas desta task",
     )
     acceptance_criteria: list[str] = Field(
-        description="Critérios de aceitação verificáveis (checklist)"
+        description="Critérios de aceitação verificáveis derivados dps RFs, RNFs e decisões de designe"
     )
     contract: Contract = Field(
         description="Fronteiras: o que ler e o que produzir"
     )
     requirement_id: str = Field(
         description=(
-            "ID do requisito de origem que motivou esta task "
-            "(ex: RF-001). Garante a rastreabilidade."
+            "ID do requisito funcional de origem desta task "
+            "(ex: RF-001). Garante a rastreabilidade até o time de Requisitos."
         )
     )
     design_refs: list[str] = Field(
         description=(
-            "Paths dos artefatos de design referenciados por esta task. "
-            "Pode incluir diagramas mermaid, relatórios de arquitetura mínima "
-            "e análises técnicas por HU. "
-            "Todos sob workspace_output/sessions/<session_id>/design/. "
-            "Deve conter ao menos um artefato."
+            "Referência aos artefatos de design e arquitetura que motivara, essa esta task. "
+            "Pode incluir nomes de diagramas, relatórios de arquitetura mínima e análises técnicas por HU. "
+            "Deve conter ao menos uma referência."
         )
     )
 

--- a/adk/src/agents/context_engineer/schemas.py
+++ b/adk/src/agents/context_engineer/schemas.py
@@ -99,6 +99,13 @@ class Task(BaseModel):
             "(ex: RF-001). Garante a rastreabilidade até o time de Requisitos."
         )
     )
+    @field_validator("requirement_id")
+    @classmethod
+    def validar_requirement_id(cls, v: str) -> str:
+        if not v or not v.startswith("RF-"):
+            raise ValueError("requirement_id deve iniciar com 'RF-' (ex: RF-001).")
+        return v
+    
     design_refs: list[str] = Field(
         description=(
             "Referência aos artefatos de design e arquitetura que motivaram esta task. "

--- a/adk/src/agents/context_engineer/schemas.py
+++ b/adk/src/agents/context_engineer/schemas.py
@@ -3,7 +3,7 @@
 Define MacroContext (contexto global do épico), Contract (fronteiras de I/O
 de cada task) e Task (Context Window completo para o coder).
 
-Atualizado para incluir a rastreabilidade entre requisitos, designe e tasks
+Atualizado para incluir a rastreabilidade entre requisitos, design e tasks
 para o enriquecimento de contexto.
 """ 
 

--- a/adk/src/agents/context_engineer/schemas.py
+++ b/adk/src/agents/context_engineer/schemas.py
@@ -7,7 +7,7 @@ Atualizado para incluir a rastreabilidade entre requisitos, designe e tasks
 para o enriquecimento de contexto.
 """ 
 
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -44,9 +44,9 @@ class Contract(BaseModel):
 
     @field_validator("interfaces", mode="before")
     @classmethod
-    def _coerce_interfaces(cls, v: Any) -> Optional[list[str]]:
+    def _coerce_interfaces(cls, v: Any) -> list[str]:
         if v is None:
-            return None
+            return []
         if isinstance(v, str):
             return [v]
         if isinstance(v, dict):
@@ -101,7 +101,7 @@ class Task(BaseModel):
     )
     design_refs: list[str] = Field(
         description=(
-            "Referência aos artefatos de design e arquitetura que motivara, essa esta task. "
+            "Referência aos artefatos de design e arquitetura que motivaram esta task. "
             "Pode incluir nomes de diagramas, relatórios de arquitetura mínima e análises técnicas por HU. "
             "Deve conter ao menos uma referência."
         )

--- a/adk/src/agents/context_engineer/tools.py
+++ b/adk/src/agents/context_engineer/tools.py
@@ -87,8 +87,7 @@ def tool_ler_workspace_fase(fase: str) -> dict:
  
     Deve ser chamada duas vezes antes de gerar qualquer task:
     - fase='requirements': lê RFs, RNFs, HUs e demais artefatos do Time de Requisitos
-    - fase='design': lê diagramas, relatórios e análises técnicas do Time de Designe
- 
+    - fase='design': lê diagramas, relatórios e análises técnicas do Time de Design
     Se a pasta da fase não existir ou estiver vazia, retorna erro e o
     agente deve PARAR — não gerar tasks sem os artefatos necessários.
  

--- a/adk/src/agents/context_engineer/tools.py
+++ b/adk/src/agents/context_engineer/tools.py
@@ -62,17 +62,17 @@ def tool_salvar_task(task_id: str, task_json: str) -> dict:
     try:
         task_data = json.loads(dados.task_json)
     except json.JSONDecodeError as e:
-        return {"sucesso": False, "erro": f"JSON inválido: {e}", "caminho": None}
+        return {"sucesso": False, "erro": "JSON inválido: " + str(e), "caminho": None}
 
     output_dir = get_agent_workspace("context_engineer")
-    output_file = output_dir / f"{dados.task_id}.json"
+    output_file = output_dir / (dados.task_id + ".json")
     try:
         output_dir.mkdir(parents=True, exist_ok=True)
         output_file.write_text(
             json.dumps(task_data, indent=2, ensure_ascii=False),
             encoding="utf-8",
         )
-        logger.info(f"[CONTEXT ENGINEER] Task salva: {output_file.resolve()}")
+        logger.info("[CONTEXT ENGINEER] Task salva: " + str(output_file.resolve()))
         return {
             "sucesso": True,
             "erro": None,
@@ -80,7 +80,7 @@ def tool_salvar_task(task_id: str, task_json: str) -> dict:
             "task_id": dados.task_id,
         }
     except Exception as e:
-        return {"sucesso": False, "erro": f"Erro ao salvar task: {e}", "caminho": None}
+        return {"sucesso": False, "erro": "Erro ao salvar task: " + str(e), "caminho": None}
 
 def tool_ler_workspace_fase(fase: str) -> dict:
     """Lê todos os artefatos de uma fase diretamente do workspace.
@@ -146,7 +146,7 @@ def tool_ler_workspace_fase(fase: str) -> dict:
                 "path": str(arquivo.relative_to(workspace_root)),
                 "nome": arquivo.name,
                 "tipo": arquivo.suffix.lstrip("."),
-                "conteúdo": conteudo,
+                "conteudo": conteudo,
             })
             logger.info(
                 "[CONTEXT ENGINEER] Artefato lido ["

--- a/adk/src/agents/context_engineer/tools.py
+++ b/adk/src/agents/context_engineer/tools.py
@@ -2,12 +2,12 @@
 
 Persistência de tasks contextualizadas como JSON no workspace centralizado.
 
-Phase 2.E: migrado para usar get_agent_workspace() — escreve em workspace/tasks/
-em vez do antigo artefatos/tasks/ hardcoded.
+Leitura de artefatos de requisitos e design a partir dos paths informafos pelo manifesto de cada fase.
 """
 
 import json
 import logging
+from pathlib import Path
 
 from pydantic import BaseModel, Field, field_validator, ValidationError
 from google.adk.tools import FunctionTool
@@ -27,6 +27,32 @@ class SalvarTaskSchema(BaseModel):
             raise ValueError(f"task_id deve iniciar com 'TASK-'. Recebido: '{v}'")
         return v
 
+class LerArtefatosManifestoSchema(BaseModel):
+    paths: list[str] = Field(
+        ...,
+        description=(
+            "Lista de paths individuais dos artefatos informados pelo manifesto da fase anterior. Cada path aponta para um arquivo especifico no workspace."
+        )
+    )
+    fase: str = Field(
+        ...,
+        description="Fase de origem dos artefatos: 'requirements' ou 'design'"
+    )
+ 
+    @field_validator("paths")
+    def validar_paths(cls, v):
+        if not v:
+            raise ValueError("A lista de paths não pode estar vazia.")
+        return v
+ 
+    @field_validator("fase")
+    def validar_fase(cls, v):
+        fases_validas = ("requirements", "design")
+        if v not in fases_validas:
+            raise ValueError(
+                "fase deve ser uma de: " + str(fases_validas) + ". Recebido: " + v
+            )
+        return v
 
 def tool_salvar_task(task_id: str, task_json: str) -> dict:
     """Salva uma task contextualizada como JSON em workspace/tasks/.
@@ -69,5 +95,82 @@ def tool_salvar_task(task_id: str, task_json: str) -> dict:
     except Exception as e:
         return {"sucesso": False, "erro": f"Erro ao salvar task: {e}", "caminho": None}
 
+def tool_ler_artefatos_manifesto(paths: list[str], fase: str) -> dict:
+    """Lê os artefatos de uma fase à partir dos paths individuais do manifesto.
+ 
+    Deve ser chamada duas vezes antes de gerar qualquer task:
+    - fase='requirements': lê HUs, RFs, RNFs, casos de uso, regras de negócio
+    - fase='design': lê diagramas mermaid, relatórios e análises técnicas por HU
+ 
+    Se qualquer path não existir no disco, a tool retorna erro e o agente
+    deve PARAR — nao gerar tasks sem todos os artefatos necessários.
+ 
+    Args:
+        paths (list[str]): Paths individuais dos artefatos informados pelo manifesto.
+        fase (str): Fase de origem: 'requirements' ou 'design'.
+ 
+    Returns:
+        dict: sucesso, fase, artefatos lidos com conteúdo, paths não encontrados.
+    """
+    try:
+        dados = LerArtefatosManifestoSchema(paths=paths, fase=fase)
+    except ValidationError as e:
+        return {"sucesso": False, "erro": str(e), "artefatos": None}
+ 
+    artefatos = []
+    paths_nao_encontrados = []
+ 
+    for path_str in dados.paths:
+        path = Path(path_str)
+ 
+        if not path.exists():
+            paths_nao_encontrados.append(path_str)
+            logger.error(
+                "[CONTEXT ENGINEER] Artefato não encontrado ["
+                + dados.fase + "]: " + path_str
+            )
+            continue
+ 
+        try:
+            conteudo = path.read_text(encoding="utf-8")
+            artefatos.append({
+                "path": path_str,
+                "tipo": path.suffix.lstrip("."),
+                "nome": path.name,
+                "fase": dados.fase,
+                "conteúdo": conteudo,
+            })
+            logger.info(
+                "[CONTEXT ENGINEER] Artefato lido ["
+                + dados.fase + "]: " + path_str
+            )
+        except Exception as e:
+            paths_nao_encontrados.append(path_str)
+            logger.error(
+                "[CONTEXT ENGINEER] Erro ao ler ["
+                + dados.fase + "] " + path_str + ": " + str(e)
+            )
+ 
+    if paths_nao_encontrados:
+        return {
+            "sucesso": False,
+            "erro": (
+                "Os seguintes artefatos da fase '" + dados.fase
+                + "' não foram encontrados ou não puderam ser lidos: "
+                + str(paths_nao_encontrados)
+                + ". Verifique se a fase anterior concluiu corretamente."
+            ),
+            "artefatos": None,
+            "paths_não_encontrados": paths_nao_encontrados,
+        }
+ 
+    return {
+        "sucesso": True,
+        "erro": None,
+        "fase": dados.fase,
+        "artefátos": artefatos,
+        "total_lidos": len(artefatos),
+    }
 
 tool_salvar_task_adk = FunctionTool(tool_salvar_task)
+tool_ler_artefatos_manifesto_adk = FunctionTool(tool_ler_artefatos_manifesto)

--- a/adk/src/agents/context_engineer/tools.py
+++ b/adk/src/agents/context_engineer/tools.py
@@ -101,7 +101,7 @@ def tool_ler_workspace_fase(fase: str) -> dict:
     try:
         dados = LerWorkspaceFaseSchema(fase=fase)
     except ValidationError as e:
-        return {"sucesso": False, "erro": str(e), "artefatos": None}
+        return {"sucesso": False, "erro": str(e), "fase": fase, "artefatos": None}
  
     workspace_root = get_workspace_root()
     mapeamento_fases = {
@@ -122,14 +122,17 @@ def tool_ler_workspace_fase(fase: str) -> dict:
             "caminho_esperado": str(pasta_fase),
         }
  
-    arquivos = [
-    a
-    for a in pasta_fase.rglob("*")
-    if a.is_file()
-    and a.suffix.lower() in {".md", ".txt", ".json", ".yml", ".yaml", ".mmd", ".mermaid"}
-    and not any(part.startswith(".") for part in a.relative_to(pasta_fase).parts)
-    and a.stat().st_size <= 500_000
-]
+    arquivos = sorted(
+         [
+             a
+             for a in pasta_fase.rglob("*")
+             if a.is_file()
+             and a.suffix.lower() in {".md", ".txt", ".json", ".yml", ".yaml", ".mmd", ".mermaid"}
+             and not any(part.startswith(".") for part in a.relative_to(pasta_fase).parts)
+             and a.stat().st_size <= 500_000
+         ],
+         key=lambda p: str(p.relative_to(pasta_fase)),
+     )
  
     if not arquivos:
         return {

--- a/adk/src/agents/context_engineer/tools.py
+++ b/adk/src/agents/context_engineer/tools.py
@@ -1,8 +1,8 @@
 """Tools do Agente Context Engineer.
 
 Persistência de tasks contextualizadas como JSON no workspace centralizado.
+Leitura de artefatos de requisitos e design diretamente do workspace.
 
-Leitura de artefatos de requisitos e design a partir dos paths informafos pelo manifesto de cada fase.
 """
 
 import json
@@ -12,7 +12,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field, field_validator, ValidationError
 from google.adk.tools import FunctionTool
 
-from shared.workspace import get_agent_workspace
+from shared.workspace import get_agent_workspace, get_workspace_root
 
 logger = logging.getLogger(__name__)
 
@@ -27,23 +27,11 @@ class SalvarTaskSchema(BaseModel):
             raise ValueError(f"task_id deve iniciar com 'TASK-'. Recebido: '{v}'")
         return v
 
-class LerArtefatosManifestoSchema(BaseModel):
-    paths: list[str] = Field(
-        ...,
-        description=(
-            "Lista de paths individuais dos artefatos informados pelo manifesto da fase anterior. Cada path aponta para um arquivo especifico no workspace."
-        )
-    )
+class LerWorkspaceFaseSchema(BaseModel):
     fase: str = Field(
         ...,
-        description="Fase de origem dos artefatos: 'requirements' ou 'design'"
+        description="Fase cujos artefatos serão lidos: 'requirements' ou 'design'"
     )
- 
-    @field_validator("paths")
-    def validar_paths(cls, v):
-        if not v:
-            raise ValueError("A lista de paths não pode estar vazia.")
-        return v
  
     @field_validator("fase")
     def validar_fase(cls, v):
@@ -95,82 +83,97 @@ def tool_salvar_task(task_id: str, task_json: str) -> dict:
     except Exception as e:
         return {"sucesso": False, "erro": f"Erro ao salvar task: {e}", "caminho": None}
 
-def tool_ler_artefatos_manifesto(paths: list[str], fase: str) -> dict:
-    """Lê os artefatos de uma fase à partir dos paths individuais do manifesto.
+def tool_ler_workspace_fase(fase: str) -> dict:
+    """Lê todos os artefatos de uma fase diretamente do workspace.
  
     Deve ser chamada duas vezes antes de gerar qualquer task:
-    - fase='requirements': lê HUs, RFs, RNFs, casos de uso, regras de negócio
-    - fase='design': lê diagramas mermaid, relatórios e análises técnicas por HU
+    - fase='requirements': lê RFs, RNFs, HUs e demais artefatos do Time de Requisitos
+    - fase='design': lê diagramas, relatórios e análises técnicas do Time de Designe
  
-    Se qualquer path não existir no disco, a tool retorna erro e o agente
-    deve PARAR — nao gerar tasks sem todos os artefatos necessários.
+    Se a pasta da fase não existir ou estiver vazia, retorna erro e o
+    agente deve PARAR — não gerar tasks sem os artefatos necessários.
  
     Args:
-        paths (list[str]): Paths individuais dos artefatos informados pelo manifesto.
-        fase (str): Fase de origem: 'requirements' ou 'design'.
+        fase (str): Fase cujos artefatos serão lidos: 'requirements' ou 'design'.
  
     Returns:
-        dict: sucesso, fase, artefatos lidos com conteúdo, paths não encontrados.
+        dict: sucesso, fase, artefatos lidos com conteúdo, caminho e erros.
     """
     try:
-        dados = LerArtefatosManifestoSchema(paths=paths, fase=fase)
+        dados = LerWorkspaceFaseSchema(fase=fase)
     except ValidationError as e:
         return {"sucesso": False, "erro": str(e), "artefatos": None}
  
+    workspace_root = get_workspace_root()
+    mapeamento_fases = {
+        "requirements": "requirements",
+        "design": "design",
+    }
+    pasta_fase = workspace_root / mapeamento_fases[dados.fase]
+ 
+    if not pasta_fase.exists():
+        return {
+            "sucesso": False,
+            "erro": (
+                "Pasta da fase '" + dados.fase + "' não encontrada em: "
+                + str(pasta_fase)
+                + ". Verifique se a fase anterior concluiu com sucesso."
+            ),
+            "artefatos": None,
+            "caminho_esperado": str(pasta_fase),
+        }
+ 
+    arquivos = [a for a in pasta_fase.rglob("*") if a.is_file()]
+ 
+    if not arquivos:
+        return {
+            "sucesso": False,
+            "erro": (
+                "Pasta da fase '" + dados.fase + "' existe mas está vazia: "
+                + str(pasta_fase)
+                + ". A fase anterior pode não ter persistido seus artefatos."
+            ),
+            "artefatos": None,
+            "caminho_esperado": str(pasta_fase),
+        }
+ 
     artefatos = []
-    paths_nao_encontrados = []
+    erros = []
  
-    for path_str in dados.paths:
-        path = Path(path_str)
- 
-        if not path.exists():
-            paths_nao_encontrados.append(path_str)
-            logger.error(
-                "[CONTEXT ENGINEER] Artefato não encontrado ["
-                + dados.fase + "]: " + path_str
-            )
-            continue
- 
+    for arquivo in arquivos:
         try:
-            conteudo = path.read_text(encoding="utf-8")
+            conteudo = arquivo.read_text(encoding="utf-8")
             artefatos.append({
-                "path": path_str,
-                "tipo": path.suffix.lstrip("."),
-                "nome": path.name,
-                "fase": dados.fase,
+                "path": str(arquivo.relative_to(workspace_root)),
+                "nome": arquivo.name,
+                "tipo": arquivo.suffix.lstrip("."),
                 "conteúdo": conteudo,
             })
             logger.info(
                 "[CONTEXT ENGINEER] Artefato lido ["
-                + dados.fase + "]: " + path_str
+                + dados.fase + "]: " + str(arquivo)
             )
         except Exception as e:
-            paths_nao_encontrados.append(path_str)
+            erros.append(str(arquivo) + ": " + str(e))
             logger.error(
-                "[CONTEXT ENGINEER] Erro ao ler ["
-                + dados.fase + "] " + path_str + ": " + str(e)
+                "[CONTEXT ENGINEER] Erro ao ler " + str(arquivo) + ": " + str(e)
             )
  
-    if paths_nao_encontrados:
+    if erros:
         return {
             "sucesso": False,
-            "erro": (
-                "Os seguintes artefatos da fase '" + dados.fase
-                + "' não foram encontrados ou não puderam ser lidos: "
-                + str(paths_nao_encontrados)
-                + ". Verifique se a fase anterior concluiu corretamente."
-            ),
-            "artefatos": None,
-            "paths_não_encontrados": paths_nao_encontrados,
+            "erro": "Erros ao ler artefatos: " + str(erros),
+            "artefatos": artefatos if artefatos else None,
         }
  
     return {
         "sucesso": True,
         "erro": None,
         "fase": dados.fase,
-        "artefátos": artefatos,
+        "artefatos": artefatos,
         "total_lidos": len(artefatos),
+        "caminho_pasta": str(pasta_fase),
     }
 
 tool_salvar_task_adk = FunctionTool(tool_salvar_task)
-tool_ler_artefatos_manifesto_adk = FunctionTool(tool_ler_artefatos_manifesto)
+tool_ler_workspace_fase_adk = FunctionTool(tool_ler_workspace_fase)

--- a/adk/src/agents/context_engineer/tools.py
+++ b/adk/src/agents/context_engineer/tools.py
@@ -7,7 +7,6 @@ Leitura de artefatos de requisitos e design diretamente do workspace.
 
 import json
 import logging
-from pathlib import Path
 
 from pydantic import BaseModel, Field, field_validator, ValidationError
 from google.adk.tools import FunctionTool
@@ -142,7 +141,7 @@ def tool_ler_workspace_fase(fase: str) -> dict:
  
     for arquivo in arquivos:
         try:
-            conteudo = arquivo.read_text(encoding="utf-8")
+            conteudo = arquivo.read_text(encoding="utf-8", errors="replace")
             artefatos.append({
                 "path": str(arquivo.relative_to(workspace_root)),
                 "nome": arquivo.name,

--- a/adk/src/agents/context_engineer/tools.py
+++ b/adk/src/agents/context_engineer/tools.py
@@ -87,7 +87,7 @@ def tool_ler_workspace_fase(fase: str) -> dict:
  
     Deve ser chamada duas vezes antes de gerar qualquer task:
     - fase='requirements': lê RFs, RNFs, HUs e demais artefatos do Time de Requisitos
-    - fase='design': lê diagramas, relatórios e análises técnicas do Time de Designe
+    - fase='design': lê diagramas, relatórios e análises técnicas do Time de Design
  
     Se a pasta da fase não existir ou estiver vazia, retorna erro e o
     agente deve PARAR — não gerar tasks sem os artefatos necessários.
@@ -122,7 +122,14 @@ def tool_ler_workspace_fase(fase: str) -> dict:
             "caminho_esperado": str(pasta_fase),
         }
  
-    arquivos = [a for a in pasta_fase.rglob("*") if a.is_file()]
+    arquivos = [
+    a
+    for a in pasta_fase.rglob("*")
+    if a.is_file()
+    and a.suffix.lower() in {".md", ".txt", ".json", ".yml", ".yaml", ".mmd", ".mermaid"}
+    and not any(part.startswith(".") for part in a.relative_to(pasta_fase).parts)
+    and a.stat().st_size <= 500_000
+]
  
     if not arquivos:
         return {
@@ -142,6 +149,9 @@ def tool_ler_workspace_fase(fase: str) -> dict:
     for arquivo in arquivos:
         try:
             conteudo = arquivo.read_text(encoding="utf-8", errors="replace")
+            max_chars = 50_000
+            if len(conteudo) > max_chars:
+                conteudo = conteudo[:max_chars] + "\n...[TRUNCADO]..."
             artefatos.append({
                 "path": str(arquivo.relative_to(workspace_root)),
                 "nome": arquivo.name,

--- a/adk/src/agents/workflow_coding_review/cr_context_engineer.py
+++ b/adk/src/agents/workflow_coding_review/cr_context_engineer.py
@@ -34,7 +34,7 @@ _model = os.environ.get("ADK_LLM_MODEL", _DEFAULT_MODEL)
 # Tool wrapper: persiste em coder/tasks/ em vez de tasks/ (canônico)
 # ---------------------------------------------------------------------------
 
-def _tool_salvar_task_cr(task_id: str, task_json: str) -> dict:
+def tool_salvar_task_cr(task_id: str, task_json: str) -> dict:
     """Salva task contextualizada em workspace_output/coder/tasks/.
 
     Mesma lógica do tool_salvar_task canônico, mas escreve no subdir
@@ -48,17 +48,17 @@ def _tool_salvar_task_cr(task_id: str, task_json: str) -> dict:
     try:
         task_data = json.loads(dados.task_json)
     except json.JSONDecodeError as e:
-        return {"sucesso": False, "erro": f"JSON inválido: {e}", "caminho": None}
+        return {"sucesso": False, "erro": "JSON inválido: " + str(e), "caminho": None}
 
     output_dir = get_agent_workspace("cr_context_engineer")
-    output_file = output_dir / f"{dados.task_id}.json"
+    output_file = output_dir / (dados.task_id + ".json")
     try:
         output_dir.mkdir(parents=True, exist_ok=True)
         output_file.write_text(
             json.dumps(task_data, indent=2, ensure_ascii=False),
             encoding="utf-8",
         )
-        logger.info(f"[CR CONTEXT ENGINEER] Task salva: {output_file.resolve()}")
+        logger.info("[CR CONTEXT ENGINEER] Task salva: " + str(output_file.resolve()))
         return {
             "sucesso": True,
             "erro": None,
@@ -66,10 +66,10 @@ def _tool_salvar_task_cr(task_id: str, task_json: str) -> dict:
             "task_id": dados.task_id,
         }
     except Exception as e:
-        return {"sucesso": False, "erro": f"Erro ao salvar task: {e}", "caminho": None}
+        return {"sucesso": False, "erro": "Erro ao salvar task: " + str(e), "caminho": None}
 
 
-_tool_salvar_task_cr_adk = FunctionTool(_tool_salvar_task_cr)
+tool_salvar_task_cr_adk = FunctionTool(tool_salvar_task_cr)
 
 agent = LlmAgent(
     model=_model,
@@ -79,7 +79,7 @@ agent = LlmAgent(
     output_key="tasks",
     output_schema=ce_schemas.TasksOutput,
     tools=[
-        _tool_salvar_task_cr_adk,
+        tool_salvar_task_cr_adk,
         tool_ler_workspace_fase_adk,
     ],
 )

--- a/adk/src/agents/workflow_coding_review/cr_context_engineer.py
+++ b/adk/src/agents/workflow_coding_review/cr_context_engineer.py
@@ -1,8 +1,10 @@
 """Context Engineer dedicado ao workflow coding_review.
 
 Instância ajustada do context_engineer original (src/agents/context_engineer/):
-- Lê requisitos da mensagem de entrada (contexto acumulado pelo orchestrator)
-  em vez de state["requirements"].
+- Lê artefatos de requisitos e design à partir dos paths individuais
+  informados pelos manifestos das fases anteriores.
+- Enriquece cada task com rastreabilidade explicita (requirement_id,
+  design_refs) e critérios de aceitação.
 - Persiste tasks em workspace_output/coder/tasks/ (consolidado sob coder/).
 - Evita conflito de parent com o sdlc_pipeline (instância dedicada).
 """
@@ -17,7 +19,10 @@ from pydantic import ValidationError
 
 from shared.workspace import get_agent_workspace
 from src.agents.context_engineer import prompt as ce_prompt, schemas as ce_schemas
-from src.agents.context_engineer.tools import SalvarTaskSchema
+from src.agents.context_engineer.tools import (
+    SalvarTaskSchema,
+    tool_ler_artefatos_manifesto_adk,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,27 +72,118 @@ def _tool_salvar_task_cr(task_id: str, task_json: str) -> dict:
 _tool_salvar_task_cr_adk = FunctionTool(_tool_salvar_task_cr)
 
 
-# ---------------------------------------------------------------------------
-# Prompt: seção ENTRADA ajustada para ler da mensagem de entrada
-# ---------------------------------------------------------------------------
 
-_INSTRUCTION = ce_prompt.instruction.replace(
-    "Você receberá os requisitos atômicos do agente anterior via state[\"requirements\"].\n"
-    "Cada requisito contém: id, description e acceptance_criteria.\n\n"
-    "Se a entrada estiver vazia ou ausente, retorne um erro claro e encerre.",
-    "Você receberá os requisitos como parte da mensagem de entrada (contexto das\n"
-    "fases anteriores do pipeline). Extraia os requisitos atômicos do texto recebido.\n"
-    "Cada requisito contém: id, description e acceptance_criteria.\n\n"
-    "Se a entrada estiver vazia ou não contiver requisitos identificáveis, retorne\n"
-    "um erro claro e encerre.",
+_DESCRIPTION = (
+    """
+- Context Engineer dedicado ao workflow coding_review do pipeline SDLC.
+- Recebe os manifestos de requisitos e design com os paths individuais de cada artefato produzido pelas fases anteriores.
+- Lê todos os artefatos, cruza as informações e gera tasks de codificação contextualizadas com rastreabilidade completa até requisitos e design.
+- Persiste cada task em workspace_output/coder/tasks/.
+    
+    """
 )
+_INSTRUCTION = (
+    """
+# PAPEL
+- Você é um Engenheiro de Contexto sênior.
+- Sua única responsabilidade é ler os artefatos produzidos pelas fases anteriores do pipeline e transforma-los em tasks DE CODIFICAÇÃO contextualizadas para que o Agente Coder possa executar de forma autônoma, sem ambiguidade e sem perda de atenção.
+- Você NÃO implementa código. Você NÃO define requisitos.
+- Você APENAS lê, cruza e empacota o contexto para consumo do Coder.
 
+# ENTRADA
+- Você receberá dois manifestos repassados pelo orquestrador.
+- Cada manifesto possui o campo artifacts com a lista de paths individuais apontando para cada artefato produzido pela fase.
+1. Manifesto de requisitos (phase: requirements):
+- artifacts[].path: aponta para os artefatos do Time de Requisitos salvos no workspace:
+    - User Stories (HUs) com acceptance_criteria
+    - Requisitos Funcionais (RFs) com hu_parent para rastreabilidade
+    - Requisitos Não Funcionais (RNFs) com category ISO 25010
+    - Casos de uso, regras de negócio e glossário
+2. Manifesto de design (phase: design):
+- artifacts[].path: aponta para os artefatos do Time 2 salvos no workspace:
+    - diagrams/diagrama_HU-XXX.mmd: diagrama mermaid por HU
+    - reports/relatorio_HU-XXX.md: relatorio de arquitetura mínima por HU
+    - reports/analise_tecnica_HU-XXX.md: análise técnica por HU
+
+- Se qualquer manifesto estiver ausente ou com status diferente de ok, retorne erro claro e encerre sem gerar nenhuma task.
+
+# FLUXO OBRIGATÓRIO
+
+## Passo 1 — Ler artefatos de requisitos
+Chame tool_ler_artefatos_manifesto passando:
+    - paths: lista completa de artifacts[].path do manifesto de requirements
+    - fase: 'requirements'
+Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task.
+
+## Passo 2 — Ler artefatos de designe
+Chame tool_ler_artefatos_manifesto passando:
+    - paths: lista completa de artifacts[].path do manifesto de design
+    - fase: 'design'
+Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task.
+
+## Passo 3 — Extrair Contexto Macro
+Com todos os artefatos carregados de ambas as fases, sintetize:
+- summary: objetivo maior em 1 linha unindo todas as HUs recebidas.
+- tech_stack: stack tecnologica inferida dos relatórios e análises técnicas do Time 2. Se não for possivel inferir, use ['a definir'].
+- global_rules: restrições arquiteturais derivadas das análises técnicas e relatórios de arquitetura mínima. Máximo 4 regras. Se não houver, use ['Seguir padrões do projeto'].
+
+## Passo 4 — Gerar Tasks Contextualizadas
+Para CADA RF presente nos artefatos de requisitos, gere uma Task:
+
+- **id**: formato TASK-XXX (sequencial, ex: TASK-001, TASK-002).
+- **type**: classifique como frontend | backend | database | infra | test com base no conteúdo da HU e na análise técnica correspondente.
+- **complexity**: estime como low | medium | high considerando os RFs, UHs vinculados e a análise técnica do time de designe.
+- **description**: Reescreva orientada à implementação combinando a action da HU com as decisões técnicas da análise técnica correspondente de forma clara o suficiente para que o Coder saiba EXATAMENTE o que codificar.
+- **business_rules**: extraia das BusinessRules vinculadas a este RF. Se não houver regras explicitas, deixe a lista vazia.
+- **acceptance_criteria**: derive cruzando OBRIGATORIAMENTE quatro fontes:
+    1. description dos FunctionalRequirements (critérios funcionais específicos e verificáveis)
+    2. acceptance_criteria da UserStory da hu_parent referenciada no FunctionalRequirements
+    3. description dos NonFunctionalRequirements relevantes para esta RF e sua hu_parent (performance, seguranca, usabilidade — category ISO 25010)
+    4. Decisões de arquitetura da análise técnica e relatório do Time de designe (critérios de implementação específicos da stack escolhida)
+    - Cada critério deve ser testável pelo Time de QA.
+    - Formato: verbo no infinitivo + condição + resultado esperado.
+    - Exemplo: 'Retornar status 401 quando credenciais forem inválidas'
+- **contract**: defina as fronteiras com base nos artefatos de design:
+    - inputs: arquivos ou módulos que o Coder pode LER mas NÃO modificar.
+    - outputs: arquivos que o Coder deve CRIAR ou MODIFICAR.
+    - interfaces: assinaturas de rotas ou funções do diagrama mermaid.
+- **requirement_id**: ID do RF de origem (ex: RF-001).
+    - Garante a rastreabilidade explicita ate os artefatos do Time de requisitos.
+- **design_refs**: paths dos artefatos de design específicos deste RF.
+    - Inclua o diagrama mermaid, o relatório de arquitetura minima e a analise técnica correspondentes a este RF especificamente.
+    - Deve conter ao menos um path.
+
+## Passo 5 — Persistir no Workspace
+Apos gerar todas as tasks, chame _tool_salvar_task_cr para cada task individualmente passando task_id e o JSON serializado da task.
+
+## Passo 6 — Retornar Saída Estruturada
+Retorne o JSON completo conforme o schema do sistema, contendo:
+- macro_context com summary, tech_stack e global_rules
+- tasks (lista de todas as tasks geradas com rastreabilidade completa)
+
+# CRITÉRIOS DE QUALIDADE
+- Cada task deve ser autocontida: o Coder deve conseguir executá-la sem
+  precisar consultar outras tasks ou outros documentos.
+- requirement_id e design_refs são obrigatórios em toda task. Tasks sem rastreabilidade são inválidas e não devem ser geradas.
+- acceptance_criteria deve derivar das quatro fontes obrigatoriamente. Nunca derive de apenas uma fonte.
+- Limite de 8 tasks por execução. Se houver mais RFs, priorize as bloqueantes e agrupe as relacionadas.
+- Cada task deve caber em aproximadamente 1500 tokens para otimizar a janela de contexto do Coder.
+
+# SAÍDA OBRIGATÓRIA
+Responda APENAS com JSON válido conforme o schema definido pelo sistema.
+Nenhum texto adicional. Nenhum comentário. Apenas o JSON.
+Sem markdown, sem blocos de código.
+"""
+)
 agent = LlmAgent(
     model=_model,
     name="cr_context_engineer",
-    description=ce_prompt.description,
+    description=_DESCRIPTION,
     instruction=_INSTRUCTION,
     output_key="tasks",
     output_schema=ce_schemas.TasksOutput,
-    tools=[_tool_salvar_task_cr_adk],
+    tools=[
+        _tool_salvar_task_cr_adk,
+        tool_ler_artefatos_manifesto_adk,
+    ],
 )

--- a/adk/src/agents/workflow_coding_review/cr_context_engineer.py
+++ b/adk/src/agents/workflow_coding_review/cr_context_engineer.py
@@ -1,10 +1,10 @@
 """Context Engineer dedicado ao workflow coding_review.
 
 Instância ajustada do context_engineer original (src/agents/context_engineer/):
-- Lê artefatos de requisitos e design à partir dos paths individuais
-  informados pelos manifestos das fases anteriores.
+- Lê artefatos de requisitos e design diretamente do workspace em vez de
+  consumir state["requirements"] ou contexto acumulado pelo orchestrator.
 - Enriquece cada task com rastreabilidade explicita (requirement_id,
-  design_refs) e critérios de aceitação.
+  design_refs) e critérios de aceitação derivados de múltiplas fontes.
 - Persiste tasks em workspace_output/coder/tasks/ (consolidado sob coder/).
 - Evita conflito de parent com o sdlc_pipeline (instância dedicada).
 """
@@ -21,7 +21,7 @@ from shared.workspace import get_agent_workspace
 from src.agents.context_engineer import prompt as ce_prompt, schemas as ce_schemas
 from src.agents.context_engineer.tools import (
     SalvarTaskSchema,
-    tool_ler_artefatos_manifesto_adk,
+    tool_ler_workspace_fase_adk,
 )
 
 logger = logging.getLogger(__name__)
@@ -71,119 +71,15 @@ def _tool_salvar_task_cr(task_id: str, task_json: str) -> dict:
 
 _tool_salvar_task_cr_adk = FunctionTool(_tool_salvar_task_cr)
 
-
-
-_DESCRIPTION = (
-    """
-- Context Engineer dedicado ao workflow coding_review do pipeline SDLC.
-- Recebe os manifestos de requisitos e design com os paths individuais de cada artefato produzido pelas fases anteriores.
-- Lê todos os artefatos, cruza as informações e gera tasks de codificação contextualizadas com rastreabilidade completa até requisitos e design.
-- Persiste cada task em workspace_output/coder/tasks/.
-    
-    """
-)
-_INSTRUCTION = (
-    """
-# PAPEL
-- Você é um Engenheiro de Contexto sênior.
-- Sua única responsabilidade é ler os artefatos produzidos pelas fases anteriores do pipeline e transforma-los em tasks DE CODIFICAÇÃO contextualizadas para que o Agente Coder possa executar de forma autônoma, sem ambiguidade e sem perda de atenção.
-- Você NÃO implementa código. Você NÃO define requisitos.
-- Você APENAS lê, cruza e empacota o contexto para consumo do Coder.
-
-# ENTRADA
-- Você receberá dois manifestos repassados pelo orquestrador.
-- Cada manifesto possui o campo artifacts com a lista de paths individuais apontando para cada artefato produzido pela fase.
-1. Manifesto de requisitos (phase: requirements):
-- artifacts[].path: aponta para os artefatos do Time de Requisitos salvos no workspace:
-    - User Stories (HUs) com acceptance_criteria
-    - Requisitos Funcionais (RFs) com hu_parent para rastreabilidade
-    - Requisitos Não Funcionais (RNFs) com category ISO 25010
-    - Casos de uso, regras de negócio e glossário
-2. Manifesto de design (phase: design):
-- artifacts[].path: aponta para os artefatos do Time 2 salvos no workspace:
-    - diagrams/diagrama_HU-XXX.mmd: diagrama mermaid por HU
-    - reports/relatorio_HU-XXX.md: relatorio de arquitetura mínima por HU
-    - reports/analise_tecnica_HU-XXX.md: análise técnica por HU
-
-- Se qualquer manifesto estiver ausente ou com status diferente de ok, retorne erro claro e encerre sem gerar nenhuma task.
-
-# FLUXO OBRIGATÓRIO
-
-## Passo 1 — Ler artefatos de requisitos
-Chame tool_ler_artefatos_manifesto passando:
-    - paths: lista completa de artifacts[].path do manifesto de requirements
-    - fase: 'requirements'
-Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task.
-
-## Passo 2 — Ler artefatos de designe
-Chame tool_ler_artefatos_manifesto passando:
-    - paths: lista completa de artifacts[].path do manifesto de design
-    - fase: 'design'
-Se retornar sucesso=False, PARE IMEDIATAMENTE. Não gere nenhuma task.
-
-## Passo 3 — Extrair Contexto Macro
-Com todos os artefatos carregados de ambas as fases, sintetize:
-- summary: objetivo maior em 1 linha unindo todas as HUs recebidas.
-- tech_stack: stack tecnologica inferida dos relatórios e análises técnicas do Time 2. Se não for possivel inferir, use ['a definir'].
-- global_rules: restrições arquiteturais derivadas das análises técnicas e relatórios de arquitetura mínima. Máximo 4 regras. Se não houver, use ['Seguir padrões do projeto'].
-
-## Passo 4 — Gerar Tasks Contextualizadas
-Para CADA RF presente nos artefatos de requisitos, gere uma Task:
-
-- **id**: formato TASK-XXX (sequencial, ex: TASK-001, TASK-002).
-- **type**: classifique como frontend | backend | database | infra | test com base no conteúdo da HU e na análise técnica correspondente.
-- **complexity**: estime como low | medium | high considerando os RFs, UHs vinculados e a análise técnica do time de designe.
-- **description**: Reescreva orientada à implementação combinando a action da HU com as decisões técnicas da análise técnica correspondente de forma clara o suficiente para que o Coder saiba EXATAMENTE o que codificar.
-- **business_rules**: extraia das BusinessRules vinculadas a este RF. Se não houver regras explicitas, deixe a lista vazia.
-- **acceptance_criteria**: derive cruzando OBRIGATORIAMENTE quatro fontes:
-    1. description dos FunctionalRequirements (critérios funcionais específicos e verificáveis)
-    2. acceptance_criteria da UserStory da hu_parent referenciada no FunctionalRequirements
-    3. description dos NonFunctionalRequirements relevantes para esta RF e sua hu_parent (performance, seguranca, usabilidade — category ISO 25010)
-    4. Decisões de arquitetura da análise técnica e relatório do Time de designe (critérios de implementação específicos da stack escolhida)
-    - Cada critério deve ser testável pelo Time de QA.
-    - Formato: verbo no infinitivo + condição + resultado esperado.
-    - Exemplo: 'Retornar status 401 quando credenciais forem inválidas'
-- **contract**: defina as fronteiras com base nos artefatos de design:
-    - inputs: arquivos ou módulos que o Coder pode LER mas NÃO modificar.
-    - outputs: arquivos que o Coder deve CRIAR ou MODIFICAR.
-    - interfaces: assinaturas de rotas ou funções do diagrama mermaid.
-- **requirement_id**: ID do RF de origem (ex: RF-001).
-    - Garante a rastreabilidade explicita ate os artefatos do Time de requisitos.
-- **design_refs**: paths dos artefatos de design específicos deste RF.
-    - Inclua o diagrama mermaid, o relatório de arquitetura minima e a analise técnica correspondentes a este RF especificamente.
-    - Deve conter ao menos um path.
-
-## Passo 5 — Persistir no Workspace
-Apos gerar todas as tasks, chame _tool_salvar_task_cr para cada task individualmente passando task_id e o JSON serializado da task.
-
-## Passo 6 — Retornar Saída Estruturada
-Retorne o JSON completo conforme o schema do sistema, contendo:
-- macro_context com summary, tech_stack e global_rules
-- tasks (lista de todas as tasks geradas com rastreabilidade completa)
-
-# CRITÉRIOS DE QUALIDADE
-- Cada task deve ser autocontida: o Coder deve conseguir executá-la sem
-  precisar consultar outras tasks ou outros documentos.
-- requirement_id e design_refs são obrigatórios em toda task. Tasks sem rastreabilidade são inválidas e não devem ser geradas.
-- acceptance_criteria deve derivar das quatro fontes obrigatoriamente. Nunca derive de apenas uma fonte.
-- Limite de 8 tasks por execução. Se houver mais RFs, priorize as bloqueantes e agrupe as relacionadas.
-- Cada task deve caber em aproximadamente 1500 tokens para otimizar a janela de contexto do Coder.
-
-# SAÍDA OBRIGATÓRIA
-Responda APENAS com JSON válido conforme o schema definido pelo sistema.
-Nenhum texto adicional. Nenhum comentário. Apenas o JSON.
-Sem markdown, sem blocos de código.
-"""
-)
 agent = LlmAgent(
     model=_model,
     name="cr_context_engineer",
-    description=_DESCRIPTION,
-    instruction=_INSTRUCTION,
+    description=ce_prompt.description,
+    instruction=ce_prompt.instruction,
     output_key="tasks",
     output_schema=ce_schemas.TasksOutput,
     tools=[
         _tool_salvar_task_cr_adk,
-        tool_ler_artefatos_manifesto_adk,
+        tool_ler_workspace_fase_adk,
     ],
 )

--- a/adk/tests/unit/test_context_engineer.py
+++ b/adk/tests/unit/test_context_engineer.py
@@ -21,7 +21,7 @@ def test_context_engineer_tem_output_schema():
 def test_context_engineer_tem_tool_salvar_task():
     from src.agents.context_engineer import root_agent
     # Factory injeta tool_ask_clarification_adk + tool_salvar_task
-    assert len(root_agent.tools) == 2
+    assert len(root_agent.tools) == 3
 
 
 def test_schemas_macro_context_minimal():
@@ -44,6 +44,8 @@ def test_schemas_task_com_contract():
         description="Criar endpoint POST /auth/login",
         acceptance_criteria=["Retorna 200 com JWT", "Retorna 401 com credenciais inválidas"],
         contract=Contract(inputs=[], outputs=["src/auth.py"]),
+        requirement_id="RF-001",
+        design_refs=["design/analise_tecnica_HU-001.md"],
     )
     assert task.id == "TASK-001"
     assert task.business_rules == []  # default factory
@@ -98,6 +100,8 @@ def test_schemas_tasks_output_completo():
                 description="Z",
                 acceptance_criteria=["A"],
                 contract=Contract(),
+                requirement_id="RF-001",
+                design_refs=["design/analise_tecnica_HU-001.md"],
             )
         ],
     )
@@ -136,3 +140,32 @@ def test_tool_salvar_task_json_invalido_rejeita(tmp_path, monkeypatch):
     result = tool_salvar_task("TASK-002", "not a json")
     assert result["sucesso"] is False
     assert "JSON inválido" in result["erro"] or "JSON inválido" in str(result.get("erro", ""))
+
+def test_tool_ler_workspace_fase_requirements(tmp_path, monkeypatch):
+    """tool_ler_workspace_fase le arquivos da pasta requirements."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+    pasta = tmp_path / "ws" / "requirements"
+    pasta.mkdir(parents=True)
+    (pasta / "RF-001.md").write_text("# RF-001\nDescrição do requisito", encoding="utf-8")
+    from src.agents.context_engineer.tools import tool_ler_workspace_fase
+    result = tool_ler_workspace_fase("requirements")
+    assert result["sucesso"] is True
+    assert result["total_lidos"] == 1
+    assert result["artefatos"][0]["nome"] == "RF-001.md"
+
+
+def test_tool_ler_workspace_fase_pasta_inexistente(tmp_path, monkeypatch):
+    """tool_ler_workspace_fase retorna erro se pasta nao existe."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+    from src.agents.context_engineer.tools import tool_ler_workspace_fase
+    result = tool_ler_workspace_fase("requirements")
+    assert result["sucesso"] is False
+    assert "nao encontrada" in result["erro"]
+
+
+def test_tool_ler_workspace_fase_invalida(tmp_path, monkeypatch):
+    """tool_ler_workspace_fase rejeita fase invalida."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+    from src.agents.context_engineer.tools import tool_ler_workspace_fase
+    result = tool_ler_workspace_fase("invalida")
+    assert result["sucesso"] is False

--- a/adk/tests/unit/test_context_engineer.py
+++ b/adk/tests/unit/test_context_engineer.py
@@ -20,7 +20,7 @@ def test_context_engineer_tem_output_schema():
 
 def test_context_engineer_tem_tool_salvar_task():
     from src.agents.context_engineer import root_agent
-    # Factory injeta tool_ask_clarification_adk + tool_salvar_task
+    # Factory injeta tool_ask_clarification_adk + tool_salvar_task + tool_ler_workspace_fase
     assert len(root_agent.tools) == 3
 
 
@@ -160,12 +160,12 @@ def test_tool_ler_workspace_fase_pasta_inexistente(tmp_path, monkeypatch):
     from src.agents.context_engineer.tools import tool_ler_workspace_fase
     result = tool_ler_workspace_fase("requirements")
     assert result["sucesso"] is False
-    assert "nao encontrada" in result["erro"]
+    assert "não encontrada" in result["erro"]
 
 
 def test_tool_ler_workspace_fase_invalida(tmp_path, monkeypatch):
     """tool_ler_workspace_fase rejeita fase invalida."""
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
     from src.agents.context_engineer.tools import tool_ler_workspace_fase
-    result = tool_ler_workspace_fase("invalida")
+    result = tool_ler_workspace_fase("inválida")
     assert result["sucesso"] is False

--- a/adk/tests/unit/test_context_engineer.py
+++ b/adk/tests/unit/test_context_engineer.py
@@ -20,8 +20,9 @@ def test_context_engineer_tem_output_schema():
 
 def test_context_engineer_tem_tool_salvar_task():
     from src.agents.context_engineer import root_agent
-    # Factory injeta tool_ask_clarification_adk + tool_salvar_task + tool_ler_workspace_fase
-    assert len(root_agent.tools) == 3
+    # Garante que as tools do agente incluem as funções essenciais (evita teste frágil por contagem).
+    tool_names = {getattr(getattr(t, "func", t), "__name__", "") for t in root_agent.tools}
+    assert {"tool_salvar_task", "tool_ler_workspace_fase"} <= tool_names
 
 
 def test_schemas_macro_context_minimal():


### PR DESCRIPTION
O que foi feito

schemas.py
- Foi adicionado o campo obrigatório 'requirement_id' na 'Task': É o que garante a rastreabilidade explícita até o requisito funcional de origem (ex: RF-001)
- Foi adicionado o campo obrigatório 'design_refs' na 'Task': Trata-se de uma lista de referências aos artefatos de design e arquitetura que motivaram a task

tools.py
- Foi adicionada a tool 'tool_ler_workspace_fase': Ela permite ler todos os artefatos de uma fase diretamente do workspace (requirements/ ou design/)
- Se a pasta da fase não existir ou estiver vazia, retorna erro e o agente para.

prompt.py
- O Agente foi atualizado para ler os artefatos do workspace antes de gerar qualquer task
- O 'acceptance_criteria' é derivado obrigatoriamente de quatro fontes:
  1. UserStory vinculada ao RF via hu_parent
  2. description do próprio RF
  3. RNFs relevantes (ISO 25010)
  4. Decisões de arquitetura lidas do workspace
- Foi removida a dependência de state["requirements"] para orientar o agente a ler tudo do workspace

cr_context_engineer.py
- Instância do workflow atualizada para usar 'tool_ler_workspace_fase'
- Instruction alinhada com o novo fluxo de leitura do workspace
