### PR TITLE
feat(coder): #303 Etapa 0 "Plano-Contrato" no cr_coder + leitura do contrato do workspace

### DIFF
--- a/adk/src/agents/workflow_coding_review/cr_coder.py
+++ b/adk/src/agents/workflow_coding_review/cr_coder.py
@@ -222,6 +222,35 @@ Qualquer erro abaixo causa falha total do build ou crash no runtime.
       ensaio = relationship("Ensaio", back_populates="fotos")
   ```
 
+## Jinja2Templates.TemplateResponse — use a API NOVA (Starlette ≥ 1.0)
+- A assinatura ANTIGA (nome do template como 1º argumento e request dentro do
+  dict de contexto) QUEBRA em Starlette ≥ 1.0 com
+  `TypeError: unhashable type: 'dict'` → HTTP 500 em TODA rota que renderiza template.
+- SEMPRE passe `request` como PRIMEIRO argumento posicional.
+- NUNCA coloque `request` dentro do dict de contexto.
+- Exemplo CORRETO:
+  ```python
+  from fastapi import Request
+  from fastapi.templating import Jinja2Templates
+
+  templates = Jinja2Templates(directory="templates")
+
+  @app.get("/login")
+  def login_page(request: Request):
+      return templates.TemplateResponse(
+          request,
+          "login.html",
+          {{"user": user, "errors": errors}},
+      )
+  ```
+- Exemplo ERRADO (assinatura antiga — NUNCA use):
+  ```python
+  return templates.TemplateResponse(
+      "login.html",
+      {{"request": request, "user": user, "errors": errors}},
+  )
+  ```
+
 ## Imports consistentes com requirements.txt
 - Todo `import X` ou `from X import ...` no código DEVE ter o pacote
   correspondente no requirements.txt. Se importou, deve estar listado.

--- a/adk/src/agents/workflow_coding_review/cr_coder.py
+++ b/adk/src/agents/workflow_coding_review/cr_coder.py
@@ -18,6 +18,8 @@ from shared.workspace import get_agent_workspace, get_workspace_root
 from shared.tools import (
     tool_criar_arquivo,
     tool_ler_arquivo,
+    tool_ler_workspace,
+    tool_listar_workspace,
     tool_substituir_trecho,
 )
 from src.agents.coder import prompt as coder_prompt
@@ -89,11 +91,13 @@ Você opera dentro de um LOOP junto com um Executor Docker.
 O Executor testa seu código em container após cada iteração.
 
 ## Primeira execução (campo execution_result AUSENTE no contexto):
-Implemente o projeto COMPLETO conforme os requisitos/tasks recebidos.
-Siga todas as regras abaixo normalmente.
+PRIMEIRO execute a ETAPA 0 (logo abaixo) e crie o PLAN.md.
+DEPOIS implemente o projeto COMPLETO seguindo esse plano e as regras abaixo.
 
 ## Re-execução após falha (campo execution_result PRESENTE no contexto):
 O Executor Docker detectou um ERRO na sua implementação anterior.
+NÃO refaça a ETAPA 0 e NÃO recrie o projeto. Se precisar da visão geral,
+releia o `PLAN.md` com `tool_ler_arquivo("PLAN.md")` apenas como referência.
 Analise os logs abaixo para identificar a causa raiz e corrija o código.
 
 --- RESULTADO DA EXECUÇÃO ANTERIOR ---
@@ -119,15 +123,53 @@ Exemplos de erros comuns que você receberá:
 - "COPY failed: file not found" → ajuste COPY no Dockerfile para paths existentes
 - "NameError: name 'X' is not defined" → adicione o import faltante no arquivo indicado
 
+# ETAPA 0 — PLANO ANCORADO NO CONTRATO (OBRIGATÓRIA, SÓ NA PRIMEIRA EXECUÇÃO)
+Antes de criar QUALQUER arquivo de código, execute esta etapa na ordem abaixo
+(uma tool por vez). Ela existe para você NÃO perder o fio ao gerar o projeto:
+imports sem pacote no requirements.txt, COPY/CMD apontando para arquivo que não
+existe, rota do contrato esquecida. O plano é a sua fonte da verdade.
+
+1. STACK: adote a `tech_stack` e as `global_rules` do contrato que você recebeu
+   no histórico desta sessão (a saída do agente de contexto, logo antes de você).
+   Só DECIDA uma stack por conta própria (justificando) se o contrato disser
+   "a definir" ou não trouxer stack.
+2. CONTRATOS POR TASK: leia-os do disco —
+   `tool_listar_workspace("coder/tasks")` e depois
+   `tool_ler_workspace("coder/tasks/TASK-XXX.json")` para cada task.
+   Se a listagem falhar OU os arquivos divergirem das tasks que você viu no
+   histórico, use as tasks do histórico (é a fonte que sempre existe).
+3. PLAN.md: crie o arquivo `PLAN.md` (via `tool_criar_arquivo`) contendo:
+   - Stack adotada (+ justificativa, se você a decidiu).
+   - Manifesto de arquivos: cada arquivo → responsabilidade → task(s)/interface(s)
+     que ele atende. UM arquivo por responsabilidade; consolide outputs que se
+     repetem entre tasks (não crie dois arquivos para a mesma coisa).
+   - Plano de dependências: cada pacote → por quê + qual `import` o exige. TODO
+     import de terceiros DEVE aparecer aqui E no requirements.txt.
+   - Checklist de interfaces: cada rota/assinatura das tasks → arquivo que a implementa.
+4. Só DEPOIS de gravar o PLAN.md, comece a criar os arquivos do projeto,
+   SEGUINDO o manifesto (não improvise fora dele).
+
+Não descreva o plano em texto na resposta — ele é o arquivo PLAN.md. Criar o
+PLAN.md via tool JÁ satisfaz a regra de "não descrever, FAZER".
+
 # WORKSPACE
 Seu diretório de trabalho é `{_CODER_WS}/`.
 Use caminhos RELATIVOS (ex: `app/main.py`, `tests/test_x.py`).
 NÃO USE git, NÃO crie branches, NÃO faça commits — essas ferramentas não existem.
 
 # FERRAMENTAS DISPONÍVEIS (APENAS ESTAS — não invente outras)
-- `tool_criar_arquivo(caminho, conteudo)`: cria/sobrescreve arquivo (caminho relativo).
-- `tool_ler_arquivo(caminho)`: lê arquivo já existente no workspace.
+Há DOIS escopos de caminho — não os confunda:
+
+## Escrita/edição — caminhos RELATIVOS ao SEU workspace (`coder/src/`)
+- `tool_criar_arquivo(caminho, conteudo)`: cria/sobrescreve arquivo (ex: `app/main.py`).
+- `tool_ler_arquivo(caminho)`: lê arquivo já existente no SEU workspace.
 - `tool_substituir_trecho(caminho, trecho_antigo, trecho_novo)`: edita trecho de arquivo existente.
+
+## Leitura do contrato — caminhos RELATIVOS à RAIZ do workspace (read-only)
+- `tool_listar_workspace(caminho)`: lista arquivos de uma pasta (ex: `coder/tasks`).
+- `tool_ler_workspace(caminho)`: lê arquivo de qualquer pasta (ex: `coder/tasks/TASK-001.json`).
+  ATENÇÃO: para ler as tasks use `tool_ler_workspace("coder/tasks/...")`, NUNCA
+  `tool_ler_arquivo("coder/tasks/...")` — este último resolve dentro de `coder/src/` e falha.
 
 # REGRA CRÍTICA — PERSISTÊNCIA OBRIGATÓRIA VIA TOOLS
 Você DEVE chamar `tool_criar_arquivo` para CADA arquivo que implementar.
@@ -294,5 +336,7 @@ agent = LlmAgent(
         _bind(FunctionTool(tool_criar_arquivo)),
         _bind(FunctionTool(tool_ler_arquivo)),
         _bind(FunctionTool(tool_substituir_trecho)),
+        _bind(FunctionTool(tool_ler_workspace)),
+        _bind(FunctionTool(tool_listar_workspace)),
     ],
 )


### PR DESCRIPTION
## Mudanças

Feedforward de processo no `cr_coder`, para melhorar a primeira
execução do loop `LoopAgent[cr_coder - cr_executor]`.

Arquivo alterado: `adk/src/agents/workflow_coding_review/cr_coder.py`.

**1. Leitura do contrato** — `tool_ler_workspace` / `tool_listar_workspace` já
existiam em `shared/tools/filesystem.py`; foram apenas registradas no `cr_coder`.
A factory as reconhece por nome (`_WORKSPACE_READ_TOOL_NAMES`) e injeta
`base_dir=workspace_root` automaticamente.

**2. Nova seção `# ETAPA 0 — PLANO ANCORADO NO CONTRATO`** — antes de criar
qualquer arquivo, na 1ª execução, o coder: (1) adota `tech_stack`/`global_rules`
do contrato, decidindo por conta própria só se vier `"a definir"`; (2) lê os
`coder/tasks/TASK-XXX.json` do disco, com fallback para o histórico; (3) grava
`PLAN.md` com manifesto de arquivos, plano de dependências (`import - requirements`)
e checklist de interfaces; (4) só então implementa, seguindo o manifesto.

**3. Ajustes de suporte** — `# MODO DE OPERAÇÃO`: em modo correção o coder não
replaneja, no máximo relê o `PLAN.md`. `# FERRAMENTAS DISPONÍVEIS`: dividida em
dois escopos (escrita relativa a `coder/src/`, leitura relativa à raiz), com
aviso contra usar `tool_ler_arquivo` para `coder/tasks/`.

**4. Commit separado** — fix da API do `Jinja2Templates.TemplateResponse` em
`# ERROS COMUNS`. A assinatura antiga quebra em Starlette ≥ 1.0 com
`TypeError: unhashable type: 'dict'` → HTTP 500 em toda rota com template.

## Explicação
O `cr_coder` gera o projeto do zero a cada run e "perde o fio": import sem pacote
no `requirements.txt`, `COPY`/`CMD` para arquivo inexistente, rota do contrato
esquecida. A defesa atual (`# ERROS COMUNS`) é feedforward negativo em prosa e
específico de stack — perde validade se a trava de stack for removida.

A Etapa 0 trava o **método**, não o **framework**. O plano é um arquivo (`PLAN.md`), não texto na resposta,
para não conflitar com a regra existente "NÃO descreva o que vai fazer — FAÇA".

Refs #303