### PR TITLE
Add mandatory traceability matrix guidance

### DIFF
--- a/adk/src/agents/requirements/few_shot.py
+++ b/adk/src/agents/requirements/few_shot.py
@@ -80,3 +80,39 @@ FEW_SHOT_GLOSSARY = """
   "source": "Documento de Especificação de Requisitos - Seção 1.3"
 }
 """
+
+FEW_SHOT_TRACEABILITY_MATRIX = """
+### EXEMPLO DE MATRIZ DE RASTREABILIDADE (PADRÃO TIME 1 - TACO-IDE)
+
+**CONTEXTO DE ENTRADA:**
+"O professor precisa criar um exercício novo para os alunos resolverem, colocando o enunciado e como vai testar se o código está certo. O sistema deve executar o código do aluno em sandbox isolada."
+
+**ARTEFATOS GERADOS NA ANÁLISE:**
+- HU-001: Criação de Exercícios de Programação
+- RF-005: Execução em Sandbox
+- RN-001: O exercício deve possuir enunciado antes de ser publicado.
+- RNF-001: O ambiente de execução deve isolar processos e arquivos temporários.
+
+**SAÍDA ESPERADA (ARTEFATO MARKDOWN):**
+
+Persistir como artefato auxiliar, por exemplo com ID `MTR-001`, em `Outros/MTR-001.md`.
+
+```md
+# Matriz de Rastreabilidade
+
+| ID do Artefato | Tipo | Descrição/Título | Origem | Motivo de Inclusão | Prioridade | Relacionamentos | Critérios de Aceitação | Caso(s) de Teste |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| HU-001 | HU | Criação de Exercícios de Programação | Descrição inicial do professor | Necessidade relatada de disponibilizar exercícios com enunciado e testes | Alta | Relaciona-se a RF-005, RN-001 | CA-1, CA-2, CA-3 | A definir |
+| RF-005 | RF | Execução em Sandbox | Necessidade de execução segura do código do aluno | Mitigar risco de comprometimento do servidor ao rodar código de terceiros | Alta | Deriva de HU-001; relaciona-se a RNF-001 | Não aplicável | A definir |
+| RN-001 | RN | Exercício deve possuir enunciado antes da publicação | Regra operacional do processo de cadastro | Garantir que o exercício seja compreensível ao aluno antes de disponibilizado | Média | Relaciona-se a HU-001 | Não aplicável | A definir |
+| RNF-001 | RNF | Isolamento de processos e arquivos temporários | Restrição técnica de segurança do ambiente | Sustentar a execução segura exigida por RF-005 | Alta | Sustenta RF-005 | Não aplicável | A definir |
+```
+
+**REGRAS OBSERVADAS NO EXEMPLO:**
+1. A coluna `Caso(s) de Teste` existe, mas não contém casos de teste inventados.
+2. As colunas `Motivo de Inclusão` e `Prioridade` seguem os atributos típicos de uma matriz de rastreabilidade de requisitos (ISO/IEC 29110 Perfil Básico / PMBOK) e são preenchidas apenas com base no que é extraído ou diretamente inferível da entrada e do CoT já documentado.
+3. `Critérios de Aceitação` referencia os CAs já especificados para HUs; para tipos sem critério de aceite próprio (RF, RN, RNF), usa-se `Não aplicável`.
+4. Os relacionamentos registram apenas vínculos explícitos ou diretamente derivados dos artefatos já produzidos.
+5. Quando faltar vínculo ou prioridade explícita, use `Não identificado` em vez de inferir.
+6. A matriz é persistida como artefato complementar e sua existência deve ser citada no `summary` do `AnalystOutput`.
+"""

--- a/adk/src/agents/requirements/prompt.py
+++ b/adk/src/agents/requirements/prompt.py
@@ -1,4 +1,10 @@
-from .few_shot import FEW_SHOT_HU, FEW_SHOT_RF, FEW_SHOT_DOUBT, FEW_SHOT_GLOSSARY
+from .few_shot import (
+  FEW_SHOT_DOUBT,
+  FEW_SHOT_GLOSSARY,
+  FEW_SHOT_HU,
+  FEW_SHOT_RF,
+  FEW_SHOT_TRACEABILITY_MATRIX,
+)
 
 description = """
 - Agente de análise e estruturação de requisitos de software.
@@ -35,6 +41,7 @@ Extrair do texto de entrada:
 4. Casos de Uso (UC)
 5. Regras de Negócio (RN)
 6. Glossário de Termos
+7. Matriz de Rastreabilidade dos artefatos gerados
 
 # DIRETRIZES DE RESPOSTA
 - Tom: Estritamente técnico, analítico e conciso. Sem introduções ou conclusões genéricas.
@@ -75,11 +82,32 @@ Regra obrigatória sobre suposições:
 - Para cada artefato produzido (HU, RF, RNF, RN, Glossário), persista-o no repositório de requisitos com seu tipo, ID (padrão AAAA-999) e conteúdo Markdown.
 - A persistência é obrigatória antes de devolver a saída JSON final — sem persistência o artefato não conta como entregue.
 
+# MATRIZ DE RASTREABILIDADE (OBRIGATÓRIA)
+- Ao final da análise, gere também uma Matriz de Rastreabilidade em Markdown como artefato auxiliar consolidando os artefatos produzidos.
+- Persista a matriz usando `tool_salvar_artefato_requisito` com tipo diferente de GLOSSARIO para que ela seja salva em `Outros/`.
+- Use um ID próprio para a matriz no padrão AAAA-999 (ex.: MTR-001).
+- A matriz deve seguir o padrão de matriz de rastreabilidade de requisitos (ISO/IEC 29110 Perfil Básico / PMBOK), contendo, no mínimo, as colunas:
+  1. `ID do Artefato` — identificador único do artefato (HU-999, RF-999, RNF-999, RN-999, UC-999).
+  2. `Tipo` — HU, RF, RNF, RN ou UC.
+  3. `Descrição/Título` — descrição textual resumida do artefato.
+  4. `Origem` — a fonte do requisito na entrada (trecho, seção do documento ou stakeholder mencionado).
+  5. `Motivo de Inclusão` — o argumento/justificativa que motivou a criação do artefato (por que ele é necessário), derivado do texto de entrada.
+  6. `Prioridade` — Alta, Média ou Baixa, conforme classificado no PASSO 3/4; use `Não identificado` se a entrada não permitir classificar.
+  7. `Relacionamentos` — vínculos explícitos com outros artefatos (ex.: HU vinculada a RFs, RF vinculado à HU pai, RN associada a RFs ou UCs, RNF relacionado aos artefatos afetados).
+  8. `Critérios de Aceitação` — referência aos critérios de aceite do artefato (ex.: CA-1, CA-2 de uma HU), quando aplicável; use `Não aplicável` para tipos que não possuem critérios de aceite próprios (ex.: RNF, RN).
+  9. `Caso(s) de Teste` — coluna obrigatória, mas sem preenchimento funcional pelo agente de requisitos (ver regra abaixo).
+- O campo `Caso(s) de Teste` deve EXISTIR na matriz, porém deve permanecer sem preenchimento funcional pelo agente de requisitos. Use valor vazio, `A definir` ou equivalente neutro, sem inventar casos de teste.
+- Os campos `Motivo de Inclusão` e `Prioridade` devem ser preenchidos apenas com informações extraídas ou diretamente inferíveis do texto de entrada e do raciocínio já documentado no CoT; nunca invente justificativas ou prioridades não fundamentadas. Se a entrada não permitir determinar um desses campos, use `Não identificado`.
+- A matriz deve rastrear relações explícitas entre os artefatos gerados nesta fase, por exemplo: HU vinculada a RFs, RF vinculado à HU pai, RN associada a RFs ou UCs e RNF relacionado aos artefatos afetados quando isso estiver explícito na entrada.
+- Se não houver informação suficiente para preencher algum relacionamento entre artefatos, deixe a célula correspondente como `Não identificado` em vez de inferir.
+- A matriz é um artefato adicional de saída persistida. Ela NÃO deve criar novos campos no JSON `AnalystOutput`; mencione sua geração no campo `summary`.
+
 # EXEMPLOS DE REFERÊNCIA (FEW-SHOT)
 {FEW_SHOT_HU}
 {FEW_SHOT_RF}
 {FEW_SHOT_DOUBT}
 {FEW_SHOT_GLOSSARY}
+{FEW_SHOT_TRACEABILITY_MATRIX}
 
 # INSTRUÇÃO DE SAÍDA
 Sua resposta final deve ser o objeto JSON validado pelo schema `AnalystOutput`. Antes do JSON, descreva seu raciocínio usando o prefixo "PASSO [N]:".


### PR DESCRIPTION
Introduces a new few-shot example for a requirements traceability matrix (MTR) and updates the analyst prompt to require generating and persisting this matrix as an auxiliary artifact. The prompt now defines mandatory matrix columns, rules for relationships, acceptance criteria references, handling unknown values as `Não identificado`, and keeps `Caso(s) de Teste` present but non-functional (`A definir`/empty).