### PR TITLE
Add bidirectional traceability matrix to requirements agent

### DIFF
--- a/adk/src/agents/requirements/few_shot.py
+++ b/adk/src/agents/requirements/few_shot.py
@@ -82,37 +82,102 @@ FEW_SHOT_GLOSSARY = """
 """
 
 FEW_SHOT_TRACEABILITY_MATRIX = """
-### EXEMPLO DE MATRIZ DE RASTREABILIDADE (PADRÃO TIME 1 - TACO-IDE)
+### EXEMPLO DE MATRIZ DE RASTREABILIDADE BIDIRECIONAL (PADRÃO TIME 1 - TACO-IDE)
 
 **CONTEXTO DE ENTRADA:**
-"O professor precisa criar um exercício novo para os alunos resolverem, colocando o enunciado e como vai testar se o código está certo. O sistema deve executar o código do aluno em sandbox isolada."
+"O professor precisa criar um exercício novo para os alunos resolverem, colocando o enunciado e como vai testar se o código está certo. O sistema deve executar o código do aluno em sandbox isolada. Além disso, o sistema deve ter um limite de 5 segundos por execução de teste."
 
 **ARTEFATOS GERADOS NA ANÁLISE:**
 - HU-001: Criação de Exercícios de Programação
-- RF-005: Execução em Sandbox
-- RN-001: O exercício deve possuir enunciado antes de ser publicado.
-- RNF-001: O ambiente de execução deve isolar processos e arquivos temporários.
+- RF-005: Execução em Sandbox (deriva de HU-001)
+- RN-001: O exercício deve possuir enunciado antes de ser publicado (relacionada a HU-001)
+- RNF-001: O ambiente de execução deve isolar processos e arquivos temporários (sustenta RF-005)
+- RF-009: Limite de tempo de execução de 5 segundos por teste — **gerado sem menção explícita a uma HU de origem no texto**
 
-**SAÍDA ESPERADA (ARTEFATO MARKDOWN):**
+**PASSO DA MATRIZ (RACIOCÍNIO):**
+1. Backward: HU-001 -> origem explícita de RF-005 e RN-001 (ambos citam o mesmo cenário do professor).
+2. Backward: RF-005 -> origem de RNF-001 (isolamento sustenta a execução em sandbox).
+3. Backward: RF-009 -> **nenhuma HU de origem explícita no texto**. LACUNA detectada.
+4. Forward: HU-001 -> origina RF-005 e RN-001. OK, sem lacuna.
+5. Como RF-009 não tem origem rastreável, gera-se `lacuna_detectada=true` para RF-009 e um Doubt_Artifact correspondente (não se infere uma HU fictícia para "fechar" a lacuna).
 
-Persistir como artefato auxiliar, por exemplo com ID `MTR-001`, em `Outros/MTR-001.md`.
+**SAÍDA ESPERADA (JSON — campo `traceability_matrix` de `AnalystOutput`):**
+{
+  "id": "MTR-001",
+  "itens": [
+    {
+      "id_artefato": "HU-001",
+      "tipo": "HU",
+      "descricao": "Criação de Exercícios de Programação",
+      "origem": "Descrição inicial do professor",
+      "motivo_inclusao": "Necessidade relatada de disponibilizar exercícios com enunciado e testes",
+      "prioridade": "Alta",
+      "rastreabilidade_backward": [],
+      "rastreabilidade_forward": [
+        {"id_artefato_relacionado": "RF-005", "tipo_artefato_relacionado": "RF", "tipo_relacao": "origina"},
+        {"id_artefato_relacionado": "RN-001", "tipo_artefato_relacionado": "RN", "tipo_relacao": "origina"}
+      ],
+      "criterios_aceitacao": ["CA-1", "CA-2", "CA-3"],
+      "casos_teste": "A definir",
+      "id_agente_origem": "requirements_agent",
+      "lacuna_detectada": false,
+      "lacuna_descricao": null
+    },
+    {
+      "id_artefato": "RF-005",
+      "tipo": "RF",
+      "descricao": "Execução em Sandbox",
+      "origem": "Necessidade de execução segura do código do aluno",
+      "motivo_inclusao": "Mitigar risco de comprometimento do servidor ao rodar código de terceiros",
+      "prioridade": "Alta",
+      "rastreabilidade_backward": [
+        {"id_artefato_relacionado": "HU-001", "tipo_artefato_relacionado": "HU", "tipo_relacao": "deriva_de"}
+      ],
+      "rastreabilidade_forward": [
+        {"id_artefato_relacionado": "RNF-001", "tipo_artefato_relacionado": "RNF", "tipo_relacao": "sustentado_por"}
+      ],
+      "criterios_aceitacao": ["Não aplicável"],
+      "casos_teste": "A definir",
+      "id_agente_origem": "requirements_agent",
+      "lacuna_detectada": false,
+      "lacuna_descricao": null
+    },
+    {
+      "id_artefato": "RF-009",
+      "tipo": "RF",
+      "descricao": "Limite de tempo de execução de 5 segundos por teste",
+      "origem": "Trecho: 'sistema deve ter um limite de 5 segundos por execução de teste'",
+      "motivo_inclusao": "Restrição operacional explícita no texto",
+      "prioridade": "Não identificado",
+      "rastreabilidade_backward": [],
+      "rastreabilidade_forward": [],
+      "criterios_aceitacao": ["Não aplicável"],
+      "casos_teste": "A definir",
+      "id_agente_origem": "requirements_agent",
+      "lacuna_detectada": true,
+      "lacuna_descricao": "RF-009 não possui HU de origem explícita no texto de entrada (lacuna de rastreabilidade backward)."
+    }
+  ],
+  "lacunas_candidatas_doubt": [
+    "RF-009 sem HU de origem identificável no texto — candidato a Doubt_Artifact."
+  ],
+  "markdown": "# Matriz de Rastreabilidade\\n\\n| ID do Artefato | Tipo | Descrição/Título | Origem | Motivo de Inclusão | Prioridade | Rastreabilidade Backward | Rastreabilidade Forward | Critérios de Aceitação | Caso(s) de Teste |\\n| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\\n| HU-001 | HU | Criação de Exercícios de Programação | Descrição inicial do professor | Necessidade relatada de disponibilizar exercícios com enunciado e testes | Alta | Não identificado | RF-005, RN-001 | CA-1, CA-2, CA-3 | A definir |\\n| RF-005 | RF | Execução em Sandbox | Necessidade de execução segura do código do aluno | Mitigar risco de comprometimento do servidor ao rodar código de terceiros | Alta | HU-001 | RNF-001 | Não aplicável | A definir |\\n| RN-001 | RN | Exercício deve possuir enunciado antes da publicação | Regra operacional do processo de cadastro | Garantir que o exercício seja compreensível ao aluno antes de disponibilizado | Média | HU-001 | Nenhum | Não aplicável | A definir |\\n| RNF-001 | RNF | Isolamento de processos e arquivos temporários | Restrição técnica de segurança do ambiente | Sustentar a execução segura exigida por RF-005 | Alta | RF-005 | Nenhum | Não aplicável | A definir |\\n| RF-009 | RF | Limite de tempo de execução de 5 segundos por teste | Trecho: 'limite de 5 segundos por execução de teste' | Restrição operacional explícita no texto | Não identificado | Não identificado (LACUNA) | Nenhum | Não aplicável | A definir |\\n"
+}
 
-```md
-# Matriz de Rastreabilidade
-
-| ID do Artefato | Tipo | Descrição/Título | Origem | Motivo de Inclusão | Prioridade | Relacionamentos | Critérios de Aceitação | Caso(s) de Teste |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| HU-001 | HU | Criação de Exercícios de Programação | Descrição inicial do professor | Necessidade relatada de disponibilizar exercícios com enunciado e testes | Alta | Relaciona-se a RF-005, RN-001 | CA-1, CA-2, CA-3 | A definir |
-| RF-005 | RF | Execução em Sandbox | Necessidade de execução segura do código do aluno | Mitigar risco de comprometimento do servidor ao rodar código de terceiros | Alta | Deriva de HU-001; relaciona-se a RNF-001 | Não aplicável | A definir |
-| RN-001 | RN | Exercício deve possuir enunciado antes da publicação | Regra operacional do processo de cadastro | Garantir que o exercício seja compreensível ao aluno antes de disponibilizado | Média | Relaciona-se a HU-001 | Não aplicável | A definir |
-| RNF-001 | RNF | Isolamento de processos e arquivos temporários | Restrição técnica de segurança do ambiente | Sustentar a execução segura exigida por RF-005 | Alta | Sustenta RF-005 | Não aplicável | A definir |
-```
+**DOUBT ARTIFACT GERADO A PARTIR DA LACUNA:**
+{
+  "id_duvida": "D-003",
+  "trecho": "RF-009 (limite de 5 segundos por execução de teste)",
+  "duvida": "Não há HU explícita ou diretamente inferível associada a este RF; a origem/valor de negócio do requisito não está rastreável.",
+  "impacto": "Sem rastreabilidade backward, o requisito fica sem justificativa de negócio auditável e sem cobertura de teste vinculada a uma necessidade do usuário.",
+  "sugestao": "Confirmar se este limite decorre de uma HU já registrada (ex: HU-001) ou se deve ser tratado como RNF autônomo com justificativa própria."
+}
 
 **REGRAS OBSERVADAS NO EXEMPLO:**
-1. A coluna `Caso(s) de Teste` existe, mas não contém casos de teste inventados.
-2. As colunas `Motivo de Inclusão` e `Prioridade` seguem os atributos típicos de uma matriz de rastreabilidade de requisitos (ISO/IEC 29110 Perfil Básico / PMBOK) e são preenchidas apenas com base no que é extraído ou diretamente inferível da entrada e do CoT já documentado.
-3. `Critérios de Aceitação` referencia os CAs já especificados para HUs; para tipos sem critério de aceite próprio (RF, RN, RNF), usa-se `Não aplicável`.
-4. Os relacionamentos registram apenas vínculos explícitos ou diretamente derivados dos artefatos já produzidos.
-5. Quando faltar vínculo ou prioridade explícita, use `Não identificado` em vez de inferir.
-6. A matriz é persistida como artefato complementar e sua existência deve ser citada no `summary` do `AnalystOutput`.
+1. A matriz é bidirecional: cada item registra explicitamente `rastreabilidade_backward` (origem) e `rastreabilidade_forward` (derivados), alinhado às práticas de RTM da ISO/IEC/IEEE 29148 e do BABOK/PMBOK.
+2. O mesmo conteúdo é entregue em dois formatos consistentes: objeto estruturado (`itens`, campo JSON) e tabela (`markdown`).
+3. Os campos `id_agente_origem` e `tipo_relacao` são genéricos o suficiente para consumo por agentes futuros (Design, Codificação, Testes), sem acoplamento ao domínio do TACO-IDE.
+4. A coluna/campo `Caso(s) de Teste` existe, mas nunca é preenchida com casos de teste inventados.
+5. Lacunas de rastreabilidade (RF sem HU de origem, HU sem derivados) são marcadas em `lacuna_detectada`/`lacuna_descricao`, agregadas em `lacunas_candidatas_doubt` e resultam em um Doubt_Artifact — nunca são preenchidas com vínculos inferidos artificialmente.
+6. A matriz (JSON + Markdown) é persistida junto aos demais artefatos e sua geração — incluindo a existência de lacunas — é citada no `summary` do `AnalystOutput`.
 """

--- a/adk/src/agents/requirements/prompt.py
+++ b/adk/src/agents/requirements/prompt.py
@@ -78,29 +78,46 @@ Regra obrigatória sobre suposições:
 - Nunca faça suposições silenciosas. Toda hipótese assumida para completar uma informação ausente deve ter um Doubt_Artifact correspondente registrando: o que estava ausente, qual suposição foi feita e qual o impacto se a suposição estiver errada.
 - Um requisito gerado com suposição não-documentada é considerado incompleto.
 
+Regra obrigatória sobre lacunas de rastreabilidade:
+- Toda lacuna de rastreabilidade identificada na construção da Matriz de Rastreabilidade (PASSO da matriz, ao final do fluxo) é, por definição, uma ambiguidade/inconsistência e deve gerar um Doubt_Artifact — exemplos: RF sem HU de origem (rastreabilidade backward ausente), HU sem nenhum RF/UC associado (rastreabilidade forward ausente), RN ou RNF sem nenhum artefato relacionado.
+- Cada lacuna gera um Doubt_Artifact com: trecho/ID do artefato afetado, descrição da lacuna, motivo (por que isso compromete a rastreabilidade), impacto (ex: requisito não testável/não vinculável a valor de negócio) e sugestão (ex: "vincular RF-005 a uma HU existente ou justificar sua origem direta na entrada").
+- A existência de lacunas NÃO bloqueia por si só a entrega dos artefatos já especificados corretamente; apenas os artefatos diretamente afetados pela ambiguidade correspondente devem ser bloqueados, conforme a regra geral de bloqueio já definida acima.
+
 # PERSISTÊNCIA DOS ARTEFATOS GERADOS
 - Para cada artefato produzido (HU, RF, RNF, RN, Glossário), persista-o no repositório de requisitos com seu tipo, ID (padrão AAAA-999) e conteúdo Markdown.
 - A persistência é obrigatória antes de devolver a saída JSON final — sem persistência o artefato não conta como entregue.
 
 # MATRIZ DE RASTREABILIDADE (OBRIGATÓRIA)
-- Ao final da análise, gere também uma Matriz de Rastreabilidade em Markdown como artefato auxiliar consolidando os artefatos produzidos.
-- Persista a matriz usando `tool_salvar_artefato_requisito` com tipo diferente de GLOSSARIO para que ela seja salva em `Outros/`.
+- Ao final de todo fluxo de requisitos (mesmo que nenhuma dúvida tenha sido gerada), produza automaticamente um artefato de rastreabilidade consolidando TODOS os artefatos gerados nesta fase (HU, RF, RNF, RN, UC).
+- O formato adotado combina rastreabilidade BIDIRECIONAL, seguindo práticas reconhecidas de RTM (Requirements Traceability Matrix):
+  - Referência 1: ISO/IEC/IEEE 29148 (Systems and software engineering — Life cycle processes — Requirements engineering), sucessora do IEEE 830, que recomenda rastreabilidade forward (da origem do requisito até seus artefatos derivados) e backward (do artefato até sua origem/justificativa).
+  - Referência 2: práticas de RTM descritas no BABOK Guide (IIBA) e no PMBOK (PMI), que tratam a matriz como instrumento de verificação de cobertura (todo requisito de negócio deve ter um artefato que o implemente, e todo artefato deve remontar a uma necessidade de negócio).
+  - Rastreabilidade **backward**: de cada artefato (ex.: RF) até seu(s) artefato(s) de origem (ex.: a HU da qual ele deriva).
+  - Rastreabilidade **forward**: de cada artefato de origem (ex.: HU) até todos os artefatos que ele originou (ex.: RFs, UCs, RNs relacionados).
+- Gere DOIS formatos do mesmo artefato, sempre consistentes entre si:
+  1. **JSON** — preenchendo o campo `traceability_matrix` do schema `AnalystOutput` (objeto `TraceabilityMatrix`, com itens `TraceabilityMatrixItem` contendo os campos genéricos `id_agente_origem`, `tipo_relacao` e listas de `TraceabilityLink` para as rastreabilidades forward e backward). Este JSON é o contrato de integração para consumo futuro por outros agentes (ex.: Design, Codificação, Testes).
+  2. **Markdown** — a mesma informação, em formato de tabela, atribuída ao campo `markdown` do objeto `TraceabilityMatrix` e persistida como artefato via `tool_salvar_artefato_requisito`, com tipo diferente de GLOSSARIO para que seja salva em `Outros/`.
 - Use um ID próprio para a matriz no padrão AAAA-999 (ex.: MTR-001).
-- A matriz deve seguir o padrão de matriz de rastreabilidade de requisitos (ISO/IEC 29110 Perfil Básico / PMBOK), contendo, no mínimo, as colunas:
+- A tabela Markdown deve conter, no mínimo, as colunas:
   1. `ID do Artefato` — identificador único do artefato (HU-999, RF-999, RNF-999, RN-999, UC-999).
   2. `Tipo` — HU, RF, RNF, RN ou UC.
   3. `Descrição/Título` — descrição textual resumida do artefato.
   4. `Origem` — a fonte do requisito na entrada (trecho, seção do documento ou stakeholder mencionado).
-  5. `Motivo de Inclusão` — o argumento/justificativa que motivou a criação do artefato (por que ele é necessário), derivado do texto de entrada.
+  5. `Motivo de Inclusão` — o argumento/justificativa que motivou a criação do artefato, derivado do texto de entrada.
   6. `Prioridade` — Alta, Média ou Baixa, conforme classificado no PASSO 3/4; use `Não identificado` se a entrada não permitir classificar.
-  7. `Relacionamentos` — vínculos explícitos com outros artefatos (ex.: HU vinculada a RFs, RF vinculado à HU pai, RN associada a RFs ou UCs, RNF relacionado aos artefatos afetados).
-  8. `Critérios de Aceitação` — referência aos critérios de aceite do artefato (ex.: CA-1, CA-2 de uma HU), quando aplicável; use `Não aplicável` para tipos que não possuem critérios de aceite próprios (ex.: RNF, RN).
-  9. `Caso(s) de Teste` — coluna obrigatória, mas sem preenchimento funcional pelo agente de requisitos (ver regra abaixo).
+  7. `Rastreabilidade Backward` — artefato(s) de origem (ex.: RF-005 deriva de HU-001). Use `Não identificado` quando não houver origem explícita — e trate isso como lacuna (ver abaixo).
+  8. `Rastreabilidade Forward` — artefato(s) derivados/dependentes (ex.: HU-001 origina RF-005, UC-002). Use `Nenhum` quando o artefato não originou nenhum outro — e trate isso como lacuna quando o artefato for do tipo HU (ver abaixo).
+  9. `Critérios de Aceitação` — referência aos critérios de aceite do artefato (ex.: CA-1, CA-2 de uma HU), quando aplicável; use `Não aplicável` para tipos que não possuem critérios de aceite próprios (ex.: RNF, RN).
+  10. `Caso(s) de Teste` — coluna obrigatória, mas sem preenchimento funcional pelo agente de requisitos (ver regra abaixo).
 - O campo `Caso(s) de Teste` deve EXISTIR na matriz, porém deve permanecer sem preenchimento funcional pelo agente de requisitos. Use valor vazio, `A definir` ou equivalente neutro, sem inventar casos de teste.
 - Os campos `Motivo de Inclusão` e `Prioridade` devem ser preenchidos apenas com informações extraídas ou diretamente inferíveis do texto de entrada e do raciocínio já documentado no CoT; nunca invente justificativas ou prioridades não fundamentadas. Se a entrada não permitir determinar um desses campos, use `Não identificado`.
+- **Detecção obrigatória de lacunas de rastreabilidade**: ao montar a matriz, verifique cada artefato:
+  - Todo RF, RNF, UC ou RN deve ter ao menos um vínculo de rastreabilidade backward (origem). Se não tiver, marque `lacuna_detectada=true` no item, registre em `lacunas_candidatas_doubt` da matriz e gere o Doubt_Artifact correspondente (ver regra na seção de dúvidas).
+  - Toda HU deveria originar ao menos um RF ou UC (rastreabilidade forward). Se uma HU não originou nenhum artefato, marque `lacuna_detectada=true`, registre em `lacunas_candidatas_doubt` e gere o Doubt_Artifact correspondente.
+  - Não infira vínculos para "fechar" uma lacuna artificialmente — se o vínculo não é explícito ou diretamente derivável da entrada/CoT, a lacuna deve ser reportada, nunca mascarada.
 - A matriz deve rastrear relações explícitas entre os artefatos gerados nesta fase, por exemplo: HU vinculada a RFs, RF vinculado à HU pai, RN associada a RFs ou UCs e RNF relacionado aos artefatos afetados quando isso estiver explícito na entrada.
-- Se não houver informação suficiente para preencher algum relacionamento entre artefatos, deixe a célula correspondente como `Não identificado` em vez de inferir.
-- A matriz é um artefato adicional de saída persistida. Ela NÃO deve criar novos campos no JSON `AnalystOutput`; mencione sua geração no campo `summary`.
+- A matriz (JSON e Markdown) é persistida no mesmo repositório estruturado de artefatos que HU, RF, RNF, RN, UC e Glossário — a persistência de ambos os formatos é obrigatória antes de devolver a saída final, seguindo a mesma regra geral de "MANUSEIO DE PERSISTÊNCIA" já definida acima.
+- Mencione a geração da matriz (incluindo se houve lacunas) no campo `summary` do `AnalystOutput`.
 
 # EXEMPLOS DE REFERÊNCIA (FEW-SHOT)
 {FEW_SHOT_HU}
@@ -110,7 +127,7 @@ Regra obrigatória sobre suposições:
 {FEW_SHOT_TRACEABILITY_MATRIX}
 
 # INSTRUÇÃO DE SAÍDA
-Sua resposta final deve ser o objeto JSON validado pelo schema `AnalystOutput`. Antes do JSON, descreva seu raciocínio usando o prefixo "PASSO [N]:".
+Sua resposta final deve ser o objeto JSON validado pelo schema `AnalystOutput`, incluindo obrigatoriamente o campo `traceability_matrix` preenchido (objeto `TraceabilityMatrix`, com `itens`, `lacunas_candidatas_doubt` e `markdown`) sempre que artefatos de requisitos tiverem sido gerados nesta fase. Antes do JSON, descreva seu raciocínio usando o prefixo "PASSO [N]:".
 
 # TRATAMENTO DO CONTEXTO DE FASES ANTERIORES (CRÍTICO)
 Quando o input contém o bloco "CONTEXTO DAS FASES ANTERIORES" ou "Output de <pipeline>:", esse trecho é HISTÓRICO READ-ONLY — saída de pipelines que já rodaram antes de você (requirements_pipeline, design_pipeline, etc.).

--- a/adk/src/agents/requirements/prompt.py
+++ b/adk/src/agents/requirements/prompt.py
@@ -95,7 +95,7 @@ Regra obrigatória sobre lacunas de rastreabilidade:
   - Rastreabilidade **backward**: de cada artefato (ex.: RF) até seu(s) artefato(s) de origem (ex.: a HU da qual ele deriva).
   - Rastreabilidade **forward**: de cada artefato de origem (ex.: HU) até todos os artefatos que ele originou (ex.: RFs, UCs, RNs relacionados).
 - Gere DOIS formatos do mesmo artefato, sempre consistentes entre si:
-  1. **JSON** — preenchendo o campo `traceability_matrix` do schema `AnalystOutput` (objeto `TraceabilityMatrix`, com itens `TraceabilityMatrixItem` contendo os campos genéricos `id_agente_origem`, `tipo_relacao` e listas de `TraceabilityLink` para as rastreabilidades forward e backward). Este JSON é o contrato de integração para consumo futuro por outros agentes (ex.: Design, Codificação, Testes).
+  1. **JSON** — preenchendo o campo `traceability_matrix` do schema `AnalystOutput` (objeto `TraceabilityMatrix`, com itens `TraceabilityMatrixItem` contendo o campo genérico `id_agente_origem` e listas de `TraceabilityLink` (cada link contém `tipo_relacao`) para as rastreabilidades forward e backward). Este JSON é o contrato de integração para consumo futuro por outros agentes (ex.: Design, Codificação, Testes).
   2. **Markdown** — a mesma informação, em formato de tabela, atribuída ao campo `markdown` do objeto `TraceabilityMatrix` e persistida como artefato via `tool_salvar_artefato_requisito`, com tipo diferente de GLOSSARIO para que seja salva em `Outros/`.
 - Use um ID próprio para a matriz no padrão AAAA-999 (ex.: MTR-001).
 - A tabela Markdown deve conter, no mínimo, as colunas:

--- a/adk/src/agents/requirements/schemas.py
+++ b/adk/src/agents/requirements/schemas.py
@@ -75,7 +75,7 @@ class TraceabilityMatrixItem(BaseModel):
     lacuna_descricao: Optional[str] = Field(None, description="Descrição da lacuna encontrada, quando lacuna_detectada=True")
 
 class TraceabilityMatrix(BaseModel):
-    id: str = Field(..., description="ID da matriz (padrão AAAA-999, ex: MTR-001)")
+    id: str = Field(..., description="ID da matriz (padrão PREFIXO-999, ex: MTR-001)")
     itens: List[TraceabilityMatrixItem] = Field(default_factory=list, description="Linhas da matriz, uma por artefato rastreado")
     lacunas_candidatas_doubt: List[str] = Field(
         default_factory=list,

--- a/adk/src/agents/requirements/schemas.py
+++ b/adk/src/agents/requirements/schemas.py
@@ -40,6 +40,49 @@ class UseCase(BaseModel):
     main_flow: List[str] = Field(..., description="Passos do fluxo principal")
     post_conditions: List[str] = Field(default_factory=list, description="Estados finais esperados")
 
+class TraceabilityLink(BaseModel):
+    id_artefato_relacionado: str = Field(..., description="ID do artefato relacionado (ex: RF-005, HU-001, UC-002)")
+    tipo_artefato_relacionado: str = Field(..., description="Tipo do artefato relacionado: HU, RF, RNF, RN ou UC")
+    tipo_relacao: str = Field(
+        ...,
+        description=(
+            "Natureza do relacionamento entre os dois artefatos. Valores esperados: "
+            "'deriva_de' (rastreabilidade backward, ex: RF deriva de HU), "
+            "'origina' (rastreabilidade forward, ex: HU origina RF/UC), "
+            "'depende_de', 'sustenta', 'relaciona_com', 'restringe'."
+        ),
+    )
+
+class TraceabilityMatrixItem(BaseModel):
+    id_artefato: str = Field(..., description="ID único do artefato (HU-999, RF-999, RNF-999, RN-999, UC-999)")
+    tipo: str = Field(..., description="Tipo do artefato: HU, RF, RNF, RN ou UC")
+    descricao: str = Field(..., description="Descrição/título resumido do artefato")
+    origem: str = Field(..., description="Trecho, seção do documento ou stakeholder que originou o artefato na entrada")
+    motivo_inclusao: str = Field(..., description="Justificativa extraída/inferível da entrada e do CoT para a criação do artefato, ou 'Não identificado'")
+    prioridade: str = Field(..., description="Alta, Média, Baixa ou 'Não identificado'")
+    rastreabilidade_backward: List[TraceabilityLink] = Field(
+        default_factory=list,
+        description="Artefatos de origem deste artefato (ex: de qual HU este RF/UC/RN deriva). Vazio se não houver origem explícita."
+    )
+    rastreabilidade_forward: List[TraceabilityLink] = Field(
+        default_factory=list,
+        description="Artefatos derivados/dependentes deste artefato (ex: quais RFs/UCs/RNs esta HU originou). Vazio se não houver derivados."
+    )
+    criterios_aceitacao: List[str] = Field(default_factory=list, description="Referência aos CAs do artefato (ex: CA-1, CA-2); 'Não aplicável' para tipos sem CA próprio")
+    casos_teste: str = Field(default="A definir", description="Placeholder obrigatório, não preenchido funcionalmente pelo agente de requisitos")
+    id_agente_origem: str = Field(default="requirements_agent", description="Identificador do agente que gerou este item, para rastreabilidade multiagente")
+    lacuna_detectada: bool = Field(default=False, description="True se este artefato apresenta lacuna de rastreabilidade (ex: RF sem HU de origem, HU sem RF associado)")
+    lacuna_descricao: Optional[str] = Field(None, description="Descrição da lacuna encontrada, quando lacuna_detectada=True")
+
+class TraceabilityMatrix(BaseModel):
+    id: str = Field(..., description="ID da matriz (padrão AAAA-999, ex: MTR-001)")
+    itens: List[TraceabilityMatrixItem] = Field(default_factory=list, description="Linhas da matriz, uma por artefato rastreado")
+    lacunas_candidatas_doubt: List[str] = Field(
+        default_factory=list,
+        description="Lista de lacunas de rastreabilidade detectadas (ex: 'RF-005 sem HU de origem'), reportadas como candidatas a Doubt_Artifact"
+    )
+    markdown: str = Field(..., description="Representação completa da matriz em formato Markdown (tabela), para persistência em Outros/")
+
 class AnalystOutput(BaseModel):
     status: str = Field(..., description="Status da execução: 'concluido' ou 'bloqueado'")
     user_stories: List[UserStory] = Field(default_factory=list)
@@ -48,5 +91,9 @@ class AnalystOutput(BaseModel):
     use_cases: List[UseCase] = Field(default_factory=list)
     business_rules: List[BusinessRule] = Field(default_factory=list)
     glossary: List[GlossaryTerm] = Field(default_factory=list)
+    traceability_matrix: Optional[TraceabilityMatrix] = Field(
+        None,
+        description="Matriz de rastreabilidade bidirecional (forward/backward) gerada ao final do fluxo, persistida em MD e JSON"
+    )
     doubt_generated: bool = Field(False, description="Indica se houve geração de Doubt Artifact")
     summary: str = Field(..., description="Resumo executivo do processamento")


### PR DESCRIPTION
Replaces the simple Markdown-only traceability matrix with a structured bidirectional RTM aligned to ISO/IEC/IEEE 29148, BABOK, and PMBOK practices.

Key changes:
- New Pydantic schemas: `TraceabilityLink`, `TraceabilityMatrixItem`, `TraceabilityMatrix`
- `AnalystOutput` gains an optional `traceability_matrix` field
- Matrix now tracks explicit forward (HU → RF/UC) and backward (RF → HU) links per item
- Mandatory gap detection: artefacts without traceable origins/derivatives are flagged with `lacuna_detectada=true`, aggregated in `lacunas_candidatas_doubt`, and must generate a Doubt_Artifact
- Output is dual-format: structured JSON (for downstream agent consumption) + Markdown table (for human-readable persistence)
- Prompt and few-shot example updated to reflect all new rules and output contract