### PR TITLE
Refine traceability artifact guidance

### DIFF
--- a/adk/src/agents/requirements/prompt.py
+++ b/adk/src/agents/requirements/prompt.py
@@ -97,7 +97,7 @@ Regra obrigatória sobre lacunas de rastreabilidade:
   - Rastreabilidade **forward**: de cada artefato de origem (ex.: HU) até todos os artefatos que ele originou (ex.: RFs, UCs, RNs relacionados).
 - Gere DOIS formatos do mesmo artefato, sempre consistentes entre si:
   1. **JSON** — preenchendo o campo `traceability_matrix` do schema `AnalystOutput` (objeto `TraceabilityMatrix`, com itens `TraceabilityMatrixItem` contendo o campo genérico `id_agente_origem` e listas de `TraceabilityLink` (cada link contém `tipo_relacao`) para as rastreabilidades forward e backward). Este JSON é o contrato de integração para consumo futuro por outros agentes (ex.: Design, Codificação, Testes).
-  2. **Markdown** — a mesma informação, em formato de tabela, atribuída ao campo `markdown` do objeto `TraceabilityMatrix` e persistida como artefato via `tool_salvar_artefato_requisito`, com tipo diferente de GLOSSARIO para que seja salva em `Outros/`.
+  2. **Markdown** — a mesma informação, em formato de tabela, atribuída ao campo `markdown` do objeto `TraceabilityMatrix` e persistida como artefato via `tool_salvar_artefato_requisito`, com tipo próprio `RASTREABILIDADE` (não `GLOSSARIO`), no mesmo repositório estruturado dos demais artefatos.
 - Use um ID próprio para a matriz no padrão AAAA-999 (ex.: MTR-001).
 - A tabela Markdown deve conter, no mínimo, as colunas:
   1. `ID do Artefato` — identificador único do artefato (HU-999, RF-999, RNF-999, RN-999, UC-999).

--- a/adk/src/agents/requirements/schemas.py
+++ b/adk/src/agents/requirements/schemas.py
@@ -81,7 +81,7 @@ class TraceabilityMatrix(BaseModel):
         default_factory=list,
         description="Lista de lacunas de rastreabilidade detectadas (ex: 'RF-005 sem HU de origem'), reportadas como candidatas a Doubt_Artifact"
     )
-    markdown: str = Field(..., description="Representação completa da matriz em formato Markdown (tabela), persistida com tipo próprio RASTREABILIDADE no mesmo repositório estruturado dos demais artefatos")
+    markdown: str = Field(..., description="Representação completa da matriz em formato Markdown (tabela), persistida via tool_salvar_artefato_requisito com tipo RASTREABILIDADE (não mapeado explicitamente pela tool, será salvo em Outros/ do repositório estruturado)")
 
 class AnalystOutput(BaseModel):
     status: str = Field(..., description="Status da execução: 'concluido' ou 'bloqueado'")

--- a/adk/src/agents/requirements/schemas.py
+++ b/adk/src/agents/requirements/schemas.py
@@ -81,7 +81,7 @@ class TraceabilityMatrix(BaseModel):
         default_factory=list,
         description="Lista de lacunas de rastreabilidade detectadas (ex: 'RF-005 sem HU de origem'), reportadas como candidatas a Doubt_Artifact"
     )
-    markdown: str = Field(..., description="Representação completa da matriz em formato Markdown (tabela), para persistência em Outros/")
+    markdown: str = Field(..., description="Representação completa da matriz em formato Markdown (tabela), persistida com tipo próprio RASTREABILIDADE no mesmo repositório estruturado dos demais artefatos")
 
 class AnalystOutput(BaseModel):
     status: str = Field(..., description="Status da execução: 'concluido' ou 'bloqueado'")
@@ -97,3 +97,4 @@ class AnalystOutput(BaseModel):
     )
     doubt_generated: bool = Field(False, description="Indica se houve geração de Doubt Artifact")
     summary: str = Field(..., description="Resumo executivo do processamento")
+    

--- a/adk/src/agents/requirements/schemas.py
+++ b/adk/src/agents/requirements/schemas.py
@@ -97,4 +97,3 @@ class AnalystOutput(BaseModel):
     )
     doubt_generated: bool = Field(False, description="Indica se houve geração de Doubt Artifact")
     summary: str = Field(..., description="Resumo executivo do processamento")
-    


### PR DESCRIPTION
Clarify that the traceability matrix markdown must be saved using the dedicated `RASTREABILIDADE` artifact type instead of `GLOSSARIO`, and update the schema description to match the structured repository storage used by other artifacts.