### PR TITLE
Feature/334 coding review manifest

### DIFF
--- a/adk/shared/tools/coding_tools/context_engineer_tools.py
+++ b/adk/shared/tools/coding_tools/context_engineer_tools.py
@@ -44,6 +44,22 @@ class DoubtArtifactSchema(BaseModel):
             raise ValueError("O Doubt Artifact deve ser um arquivo .md.")
         return v
 
+def _ler_arquivo(path: Path, workspace_root: Path):
+    """Lê um arquivo do workspace e retorna seu conteúdo como dicionário."""
+    if not path.exists() or not path.is_file():
+        return None
+    try:
+        conteudo = path.read_text(encoding="utf-8", errors="replace")
+        return {
+            "path": str(path.relative_to(workspace_root)),
+            "nome": path.name,
+            "tipo": path.suffix.lstrip("."),
+            "conteudo": conteudo,
+        }
+    except Exception as e:
+        logger.error("[CONTEXT ENGINEER] Erro ao ler " + str(path) + ": " + str(e))
+        return None
+
 def tool_salvar_task(task_id: str, task_json: str) -> dict:
     """Salva uma task contextualizada como JSON em workspace/tasks/.
 
@@ -190,65 +206,98 @@ def _ler_pasta_workspace(pasta_fase: Path, workspace_root: Path, nome_fase: str)
     }
  
 
-def tool_ler_requirements() -> dict:
-    """Lê todos os artefatos de requisitos do workspace.
- 
-    Verifica obrigatoriamente a presença de:
-    - pelo menos 1 arquivo RF-*.md em requirements/RFs/ (SEMPRE obrigatório)
- 
-    Informa separadamente se HUs existem via campo tem_hu — a ausência
-    de HUs não é bloqueante aqui. O Passo 2.5 do prompt cruza essa
-    informação com o design para determinar se é bloqueante ou não.
- 
+def tool_ler_requirements(paths_json: str) -> dict:
+    """Lê artefatos de requisitos a partir dos paths extraídos do manifesto.
+
+    O LLM extrai os paths do manifesto de requirements recebido no texto
+    do prompt (repassado pelo orquestrador) e passa para esta tool como
+    JSON serializado.
+
+    Args:
+        paths_json (str): JSON serializado com lista de dicionários contendo
+                          os paths dos artefatos extraídos do manifesto.
+                          Formato: [{"path": "requirements/HUs/HU-001.md"}, ...]
+
     Returns:
-        dict: sucesso, artefatos lidos, artefatos_minimos_presentes,
+        dict: sucesso, fase, artefatos lidos, artefatos_minimos_presentes,
               tem_hu, artefatos_minimos_ausentes e erros.
     """
     workspace_root = get_workspace_root()
-    pasta_fase = workspace_root / "requirements"
- 
-    resultado = _ler_pasta_workspace(pasta_fase, workspace_root, "requirements")
-    if not resultado["sucesso"]:
-        return resultado
- 
-    pasta_hus = pasta_fase / "HUs"
-    pasta_rfs = pasta_fase / "RFs"
- 
-    artefatos_minimos_presentes = True
+
+    try:
+        paths_list = json.loads(paths_json)
+    except json.JSONDecodeError as e:
+        return {
+            "sucesso": False,
+            "fase": "requirements",
+            "erro": "paths_json inválido — JSON malformado: " + str(e),
+            "artefatos": None,
+            "artefatos_minimos_presentes": False,
+            "tem_hu": False,
+        }
+
+    if not paths_list:
+        return {
+            "sucesso": False,
+            "fase": "requirements",
+            "erro": (
+                "Nenhum path de artefato fornecido. "
+                "Extraia os paths do manifesto de requirements recebido no prompt."
+            ),
+            "artefatos": None,
+            "artefatos_minimos_presentes": False,
+            "tem_hu": False,
+        }
+
+    artefatos = []
+    erros = []
+    tem_hu = False
+    tem_rf = False
+
+    for item in paths_list:
+        path_rel = str(item.get("path", "") if isinstance(item, dict) else item)
+        rel_path = Path(path_rel)
+        if rel_path.is_absolute() or ".." in rel_path.parts:
+            erros.append("Path inválido no manifesto: " + path_rel)
+            logger.warning("[CONTEXT ENGINEER] Path inválido no manifesto: " + path_rel)
+            continue
+        path_abs = workspace_root / rel_path
+        conteudo = _ler_arquivo(path_abs, workspace_root)
+        if conteudo:
+            artefatos.append(conteudo)
+            nome = Path(path_rel).name
+            if nome.startswith("HU-") and nome.endswith(".md"):
+                tem_hu = True
+            if nome.startswith("RF-") and nome.endswith(".md"):
+                tem_rf = True
+        else:
+            erros.append("Arquivo não encontrado: " + path_rel)
+            logger.warning("[CONTEXT ENGINEER] Artefato ausente: " + path_rel)
+
+    artefatos_minimos_presentes = tem_rf
     artefatos_minimos_ausentes = []
- 
-    tem_hu = (
-        pasta_hus.exists()
-        and any(
-            f.name.startswith("HU-") and f.suffix == ".md"
-            for f in pasta_hus.iterdir()
-            if f.is_file()
+
+    if not tem_rf:
+        artefatos_minimos_ausentes.append(
+            "Nenhum arquivo RF-*.md encontrado nos paths fornecidos"
         )
-    )
     if not tem_hu:
         artefatos_minimos_ausentes.append(
-            "Nenhum arquivo HU-*.md encontrado em requirements/HUs/ "
+            "Nenhum arquivo HU-*.md encontrado nos paths fornecidos "
             "(pode ser válido — verificar consistência com design no Passo 2.5)"
         )
- 
-    tem_rf = (
-        pasta_rfs.exists()
-        and any(
-            f.name.startswith("RF-") and f.suffix == ".md"
-            for f in pasta_rfs.iterdir()
-            if f.is_file()
-        )
-    )
-    if not tem_rf:
-        artefatos_minimos_presentes = False
-        artefatos_minimos_ausentes.append(
-            "Nenhum arquivo RF-*.md encontrado em requirements/RFs/"
-        )
- 
-    resultado["artefatos_minimos_presentes"] = artefatos_minimos_presentes
-    resultado["artefatos_minimos_ausentes"] = artefatos_minimos_ausentes
-    resultado["tem_hu"] = tem_hu
-    return resultado
+
+    return {
+        "sucesso": True,
+        "fase": "requirements",
+        "erro": None,
+        "artefatos": artefatos,
+        "total_lidos": len(artefatos),
+        "artefatos_minimos_presentes": artefatos_minimos_presentes,
+        "artefatos_minimos_ausentes": artefatos_minimos_ausentes,
+        "tem_hu": tem_hu,
+        "erros_leitura": erros if erros else None,
+    }
 
  
 def tool_ler_design() -> dict:

--- a/adk/shared/tools/coding_tools/context_engineer_tools.py
+++ b/adk/shared/tools/coding_tools/context_engineer_tools.py
@@ -53,7 +53,7 @@ def _ler_arquivo(path: Path, workspace_root: Path) -> Optional[dict]:
     try:
         conteudo = path.read_text(encoding="utf-8", errors="replace")
         return {
-            "path": str(path.relative_to(workspace_root)),
+            "path": str(path.relative_to(workspace_root)).replace("\\", "/"),
             "nome": path.name,
             "tipo": path.suffix.lstrip("."),
             "conteudo": conteudo,

--- a/adk/shared/tools/coding_tools/context_engineer_tools.py
+++ b/adk/shared/tools/coding_tools/context_engineer_tools.py
@@ -221,9 +221,8 @@ def tool_ler_requirements(paths_json: str) -> dict:
     se é bloqueante.
 
     Args:
-        paths_json (str): JSON serializado com lista de dicionários contendo
-                          os paths dos artefatos extraídos do manifesto.
-                          Formato: [{"path": "requirements/HUs/HU-001.md"}, ...]
+        paths_json (str): JSON serializado com lista de paths (strings) ou itens com chave `path`.
+                          Formatos aceitos: ["requirements/HUs/HU-001.md", ...] ou [{"path": "requirements/HUs/HU-001.md"}, ...]
 
     Returns:
         dict: sucesso, fase, artefatos lidos, artefatos_minimos_presentes,

--- a/adk/shared/tools/coding_tools/context_engineer_tools.py
+++ b/adk/shared/tools/coding_tools/context_engineer_tools.py
@@ -1,17 +1,19 @@
 """Tools do Agente Context Engineer.
 
-Persistência de tasks contextualizadas como JSON no workspace centralizado.
-Leitura de artefatos de requisitos e design diretamente do workspace.
-Geração de Doubt Artifact em caso de bloqueio.
+Persistência de tasks contextualizadas como JSON no workspace centralizado em workspace_output/coder/tasks/.
+Leitura de artefatos de requisitos via paths extraídos do manifesto pelo LLM.
+Leitura de artefatos de design diretamente do workspace (fallback enquanto o Time 2 não produz manifesto).
+Geração de Doubt Artifact e pausa HITL em caso de bloqueio.
 """
 
 import json
 import logging
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field, field_validator, ValidationError
-from google.adk.tools import FunctionTool
+from google.adk.tools import FunctionTool, LongRunningFunctionTool, ToolContext
 
 from shared.workspace import get_agent_workspace, get_workspace_root
 
@@ -44,7 +46,7 @@ class DoubtArtifactSchema(BaseModel):
             raise ValueError("O Doubt Artifact deve ser um arquivo .md.")
         return v
 
-def _ler_arquivo(path: Path, workspace_root: Path):
+def _ler_arquivo(path: Path, workspace_root: Path) -> Optional[dict]:
     """Lê um arquivo do workspace e retorna seu conteúdo como dicionário."""
     if not path.exists() or not path.is_file():
         return None
@@ -60,46 +62,6 @@ def _ler_arquivo(path: Path, workspace_root: Path):
         logger.error("[CONTEXT ENGINEER] Erro ao ler " + str(path) + ": " + str(e))
         return None
 
-def tool_salvar_task(task_id: str, task_json: str) -> dict:
-    """Salva uma task contextualizada como JSON em workspace/tasks/.
-
-    Usa get_agent_workspace("context_engineer") — o workspace é resolvido via
-    a variável de ambiente WORKSPACE_OUTPUT_DIR (default: ./workspace_output).
-
-    Args:
-        task_id (str): Identificador da task (ex: 'TASK-001').
-        task_json (str): Conteúdo JSON serializado da task completa.
-
-    Returns:
-        dict: {sucesso, erro, caminho, task_id}
-    """
-    try:
-        dados = SalvarTaskSchema(task_id=task_id, task_json=task_json)
-    except ValidationError as e:
-        return {"sucesso": False, "erro": str(e), "caminho": None}
-
-    try:
-        task_data = json.loads(dados.task_json)
-    except json.JSONDecodeError as e:
-        return {"sucesso": False, "erro": "JSON inválido: " + str(e), "caminho": None}
-
-    output_dir = get_agent_workspace("context_engineer")
-    output_file = output_dir / (dados.task_id + ".json")
-    try:
-        output_dir.mkdir(parents=True, exist_ok=True)
-        output_file.write_text(
-            json.dumps(task_data, indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
-        logger.info("[CONTEXT ENGINEER] Task salva: " + str(output_file.resolve()))
-        return {
-            "sucesso": True,
-            "erro": None,
-            "caminho": str(output_file.resolve()),
-            "task_id": dados.task_id,
-        }
-    except Exception as e:
-        return {"sucesso": False, "erro": "Erro ao salvar task: " + str(e), "caminho": None}
 
 def _ler_pasta_workspace(pasta_fase: Path, workspace_root: Path, nome_fase: str) -> dict:
     """Função interna que lê arquivos de uma pasta do workspace.
@@ -204,14 +166,59 @@ def _ler_pasta_workspace(pasta_fase: Path, workspace_root: Path, nome_fase: str)
         "total_lidos": len(artefatos),
         "caminho_pasta": str(pasta_fase),
     }
- 
+
+
+def tool_salvar_task(task_id: str, task_json: str) -> dict:
+    """Salva uma task contextualizada como JSON em workspace_output/coder/tasks/.
+
+    Args:
+        task_id (str): Identificador da task (ex: 'TASK-001').
+        task_json (str): Conteúdo JSON serializado da task completa.
+
+    Returns:
+        dict: sucesso, erro, caminho, task_id
+    """
+    try:
+        dados = SalvarTaskSchema(task_id=task_id, task_json=task_json)
+    except ValidationError as e:
+        return {"sucesso": False, "erro": str(e), "caminho": None}
+
+    try:
+        task_data = json.loads(dados.task_json)
+    except json.JSONDecodeError as e:
+        return {"sucesso": False, "erro": "JSON inválido: " + str(e), "caminho": None}
+
+    output_dir = get_agent_workspace("context_engineer")
+    output_file = output_dir / (dados.task_id + ".json")
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(
+            json.dumps(task_data, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        logger.info("[CONTEXT ENGINEER] Task salva: " + str(output_file.resolve()))
+        return {
+            "sucesso": True,
+            "erro": None,
+            "caminho": str(output_file.resolve()),
+            "task_id": dados.task_id,
+        }
+    except Exception as e:
+        return {"sucesso": False, "erro": "Erro ao salvar task: " + str(e), "caminho": None}
+
 
 def tool_ler_requirements(paths_json: str) -> dict:
     """Lê artefatos de requisitos a partir dos paths extraídos do manifesto.
 
     O LLM extrai os paths do manifesto de requirements recebido no texto
     do prompt (repassado pelo orquestrador) e passa para esta tool como
-    JSON serializado.
+    JSON serializado. A tool lê os arquivos do workspace e verifica os
+    artefatos mínimos obrigatórios.
+    
+    RF é sempre obrigatório — sem RF não há o que transformar em task.
+    HU é informada separadamente via campo tem_hu — ausência não bloqueia
+    sozinha. O Passo 2.5 do prompt cruza com o design para determinar
+    se é bloqueante.
 
     Args:
         paths_json (str): JSON serializado com lista de dicionários contendo
@@ -255,7 +262,7 @@ def tool_ler_requirements(paths_json: str) -> dict:
     tem_rf = False
 
     for item in paths_list:
-        path_rel = str(item.get("path", "") if isinstance(item, dict) else item)
+        path_rel = str(item.get("path", "") if isinstance(item, dict) else item).replace("\\", "/")
         rel_path = Path(path_rel)
         if rel_path.is_absolute() or ".." in rel_path.parts:
             erros.append("Path inválido no manifesto: " + path_rel)
@@ -300,18 +307,18 @@ def tool_ler_requirements(paths_json: str) -> dict:
     }
 
  
-def tool_ler_design() -> dict:
+def tool_ler_design(tem_hu: bool = True) -> dict:
     """Lê todos os artefatos de design do workspace.
+ 
+    Fallback enquanto o Time 2 não produz manifesto. Quando o manifesto
+    de design for implementado, esta tool será atualizada para consumir
+    os paths do manifesto via mesmo padrão da tool_ler_requirements.
  
     Verifica obrigatoriamente a presença de:
     - pelo menos 1 arquivo analise_tecnica_*.md em design/
  
-    Se o mínimo não for encontrado, retorna
-    artefatos_minimos_presentes=False para que o agente gere um
-    Doubt Artifact e pare a execução.
- 
     Returns:
-        dict: sucesso, artefatos lidos, artefatos_minimos_presentes e erros.
+        dict: sucesso, fase, artefatos lidos, artefatos_minimos_presentes e erros.
     """
     workspace_root = get_workspace_root()
     pasta_fase = workspace_root / "design"
@@ -320,11 +327,9 @@ def tool_ler_design() -> dict:
     if not resultado["sucesso"]:
         return resultado
  
-    # Verifica artefatos mínimos obrigatórios
     tem_analise = any(
-        f.name.startswith("analise_tecnica_") and f.suffix == ".md"
-        for f in pasta_fase.rglob("*.md")
-        if f.is_file()
+        a["nome"].startswith("analise_tecnica_") and a["nome"].endswith(".md")
+        for a in resultado.get("artefatos", [])
     )
  
     artefatos_minimos_ausentes = []
@@ -333,8 +338,20 @@ def tool_ler_design() -> dict:
             "Nenhum arquivo analise_tecnica_*.md encontrado em design/"
         )
  
+    # Verifica inconsistência entre times
+    inconsistencia = False
+    if not tem_hu:
+        tem_analise_hu = any(
+            a["nome"].startswith("analise_tecnica_HU-") and a["nome"].endswith(".md")
+            for a in resultado.get("artefatos", [])
+        )
+        if tem_analise_hu:
+            inconsistencia = True
+
     resultado["artefatos_minimos_presentes"] = tem_analise
     resultado["artefatos_minimos_ausentes"] = artefatos_minimos_ausentes
+    resultado["inconsistencia_detectada"] = inconsistencia
+    resultado["fallback"] = True
     return resultado
 
  
@@ -344,27 +361,26 @@ def tool_gerar_doubt_artifact(
     descricao: str,
     acao_necessaria: str,
     nome_arquivo: str = "Doubt_Artifact_context_engineer.md",
+    subdir: str = "",
 ) -> dict:
-    """Gera um Doubt Artifact ao detectar bloqueio no workspace.
+    """Gera um Doubt Artifact ao detectar bloqueio.
  
-    Use esta tool quando qualquer uma das condições abaixo ocorrer -todas são bloqueantes:
-    - A pasta requirements/ não existir no workspace
-    - A pasta design/ não existir no workspace
-    - RF-*.md ausente em requirements/RFs/
-    - analise_tecnica_*.md ausente em design/
-    - Inconsistência entre times: analise_tecnica_HU-*.md existe em design
-      mas não existe HUs/ em requirements
+    Use esta tool quando qualquer uma das condições abaixo ocorrer, todas são bloqueantes e impedem a geração de tasks:
+    - Manifesto de requirements com status=blocked ou ausente no prompt
+    - RF-*.md ausente nos paths fornecidos
+    - analise_tecnica_*.md ausente no workspace de design
+    - Inconsistência entre times
 
-    A ausência de qualquer um desses artefatos, isoladamente ou em conjunto,
-    impede a geração de tasks e exige intervenção humana.
-    Após chamar esta tool, PARE a execução. Não gere nenhuma task.
+    Após chamar esta tool, chame aguardar_resolucao_bloqueio para
+    pausar o pipeline via HITL. Não gere nenhuma task.
  
     Args:
         titulo (str): Título curto do bloqueio.
-        fase_bloqueada (str): Fase que causou o bloqueio ('requirements' ou 'design').
+        fase_bloqueada (str): Fase que causou o bloqueio.
         descricao (str): Descrição detalhada do problema encontrado.
         acao_necessaria (str): O que precisa ser feito para desbloquear.
         nome_arquivo (str): Nome do arquivo de saída.
+        subdir (str): Subdiretório do workspace onde salvar (ex: 'coder').
  
     Returns:
         dict: sucesso, caminho do arquivo gerado e status de bloqueio.
@@ -379,6 +395,15 @@ def tool_gerar_doubt_artifact(
         )
     except ValidationError as e:
         return {"sucesso": False, "erro": str(e), "caminho": None}
+
+    if subdir:
+        subdir_path = Path(subdir)
+        if subdir_path.is_absolute() or ".." in subdir_path.parts:
+            return {
+                "sucesso": False,
+                "erro": "subdir inválido — não use paths absolutos ou '..': " + subdir,
+                "caminho": None,
+            }
  
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
  
@@ -410,7 +435,8 @@ def tool_gerar_doubt_artifact(
     )
  
     workspace_root = get_workspace_root()
-    path = workspace_root / dados.nome_arquivo
+    pasta_destino = workspace_root / subdir if subdir else workspace_root
+    path = pasta_destino / dados.nome_arquivo
  
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -433,12 +459,91 @@ def tool_gerar_doubt_artifact(
             "erro": "Erro ao salvar Doubt Artifact: " + str(e),
             "caminho": None,
         }
- 
+
+def tool_emitir_manifesto_bloqueado(
+    motivo: str,
+    tool_context: ToolContext,
+) -> dict:
+    """Emite manifesto com status=blocked no state e em disco.
+
+    Use após tool_gerar_doubt_artifact e antes de aguardar_resolucao_bloqueio.
+    Garante que o manifesto seja gravado no state mesmo com pipeline pausado.
+
+    Args:
+        motivo (str): Motivo do bloqueio — usado como summary do manifesto.
+        tool_context (ToolContext): Injetado automaticamente pelo ADK.
+
+    Returns:
+        dict: sucesso, status, caminho do manifesto gravado.
+    """
+    from src.agents.workflow_coding_review.manifest import (
+        PHASE_NAME,
+        STATE_KEY,
+        _scan_artifacts,
+        _scan_doubts,
+    )
+
+    ws_root = get_workspace_root()
+    coder_ws = get_agent_workspace("coder")
+
+    artifacts = _scan_artifacts(coder_ws, ws_root)
+    doubts    = _scan_doubts(coder_ws, ws_root)
+
+    manifest: dict = {
+        "phase":     PHASE_NAME,
+        "status":    "blocked",
+        "artifacts": artifacts,
+        "doubts":    doubts,
+        "summary":   motivo,
+    }
+
+    if tool_context is not None:
+        tool_context.state[STATE_KEY] = manifest
+
+    manifest_path = coder_ws / "manifest.json"
+    try:
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        logger.info(
+            "[CONTEXT ENGINEER] Manifesto bloqueado emitido: " + str(manifest_path)
+        )
+        return {
+            "sucesso": True,
+            "status": "blocked",
+            "caminho": str(manifest_path.resolve()),
+        }
+    except Exception as e:
+        return {
+            "sucesso": False,
+            "erro": "Erro ao emitir manifesto bloqueado: " + str(e),
+            "caminho": None,
+        }
+
+
+async def aguardar_resolucao_bloqueio(
+    fase_bloqueada: str,
+    motivo: str,
+    acao_necessaria: str,
+) -> Optional[dict[str, Any]]:
+    """Pausa o pipeline até que o bloqueio seja resolvido.
+
+    Use APÓS tool_emitir_manifesto_bloqueado. O ADK interpreta retorno
+    None como função pendente, pausando o SequentialAgent e impedindo
+    o avanço para o coder.
+    """
+    _ = (fase_bloqueada, motivo, acao_necessaria)
+    return None
+
 
 tool_salvar_task_adk = FunctionTool(tool_salvar_task)
 tool_ler_requirements_adk = FunctionTool(tool_ler_requirements)
 tool_ler_design_adk = FunctionTool(tool_ler_design)
 tool_gerar_doubt_artifact_adk = FunctionTool(tool_gerar_doubt_artifact)
+tool_emitir_manifesto_bloqueado_adk = FunctionTool(tool_emitir_manifesto_bloqueado)
+tool_aguardar_resolucao_bloqueio_adk = LongRunningFunctionTool(aguardar_resolucao_bloqueio)
 
 
 def tool_salvar_task_cr(task_id: str, task_json: str) -> dict:

--- a/adk/src/agents/workflow_coding_review/agent.py
+++ b/adk/src/agents/workflow_coding_review/agent.py
@@ -25,6 +25,8 @@ from .context_engineer import agent as _context_engineer
 from .coder import agent as _coder
 from .executor.agent import agent as _executor
 from .reviewer.agent import agent as _reviewer
+from .manifest import emit_coding_manifest
+
 
 # ---------------------------------------------------------------------------
 # Loop de codificação + execução: coder produz/corrige → executor testa
@@ -51,7 +53,8 @@ agent = SequentialAgent(
     name="coding_review_pipeline",
     description=(
         "Pipeline enxuto de codificação com revisão: "
-        "contexto → [codificação ↔ execução Docker] → revisão."
+        "contexto → [codificação ↔ execução Docker] → revisão → manifesto."
     ),
     sub_agents=[_context_engineer, _code_execute_loop, _reviewer],
+    after_agent_callback=emit_coding_manifest,
 )

--- a/adk/src/agents/workflow_coding_review/context_engineer/agent.py
+++ b/adk/src/agents/workflow_coding_review/context_engineer/agent.py
@@ -1,12 +1,14 @@
 """Context Engineer dedicado ao workflow coding_review.
 
-- Lê artefatos de requisitos e design diretamente do workspace.
-- Verifica artefatos mínimos obrigatórios e gera Doubt Artifact se ausentes.
-- Enriquece cada task com rastreabilidade explícita (requirement_id,
-  design_refs) e critérios de aceitação.
-- Persiste tasks em workspace_output/coder/tasks/ (consolidado sob coder/).
-- Instância dedicada com prompt e schemas próprios, evitando conflito de parent
-  no pipeline.
+- Consome o manifesto de requirements repassado pelo orquestrador via texto
+  do prompt, seguindo o mesmo padrão do workflow_qa.
+- Lê artefatos de design diretamente do workspace (fallback enquanto o
+  Time 2 não produz manifesto).
+- Verifica status do manifesto e pausa via HITL (aguardar_resolucao_bloqueio)
+  se bloqueado, impedindo o avanço para o coder.
+- Enriquece cada task com rastreabilidade explícita (requirement_id, design_refs)
+  e critérios de aceitação derivados de múltiplas fontes.
+- Persiste tasks em workspace_output/coder/tasks/.
 """
 
 import os
@@ -19,9 +21,11 @@ from shared.tools.coding_tools.context_engineer_tools import (
     tool_ler_requirements_adk,
     tool_ler_design_adk,
     tool_gerar_doubt_artifact_adk,
+    tool_emitir_manifesto_bloqueado_adk,
+    tool_aguardar_resolucao_bloqueio_adk,
 )
 
-from . import prompt, schemas
+from . import prompt
 
 _DEFAULT_MODEL = "gemini-2.5-flash"
 _model = os.environ.get("ADK_LLM_MODEL", _DEFAULT_MODEL)
@@ -32,12 +36,13 @@ agent = LlmAgent(
     description=prompt.description,
     instruction=prompt.instruction,
     output_key="tasks",
-    output_schema=schemas.TasksOutput,
     tools=[
         tool_salvar_task_cr_adk,
         tool_salvar_macro_context_cr_adk,
         tool_ler_requirements_adk,
         tool_ler_design_adk,
         tool_gerar_doubt_artifact_adk,
+        tool_emitir_manifesto_bloqueado_adk,
+        tool_aguardar_resolucao_bloqueio_adk,
     ],
 )

--- a/adk/src/agents/workflow_coding_review/context_engineer/prompt.py
+++ b/adk/src/agents/workflow_coding_review/context_engineer/prompt.py
@@ -8,8 +8,8 @@ workspace_output/coder/tasks/ (consolidado sob coder/).
 
 description = """
 - Agente de engenharia de contexto para o pipeline SDLC.
-- Recebe os requisitos atômicos gerados pelo Agente Requirements e os transforma em tarefas de codificação contextualizadas (Context Windows), enriquecidas com rastreabilidade explícita até os requisitos e artefatos de design, e critérios de aceitação.
-- Persiste cada task como arquivo JSON individual em $WORKSPACE_OUTPUT_DIR/tasks/ (default: ./workspace_output/tasks/).
+- Consome o manifesto de requiriments repassado pelo orquestrador para gerar tarefas de codificação contextualizadas (Context Windows), enriquecidas com rastreabilidade explícita até os requisitos e artefatos de design, e critérios de aceitação derivados de múltiplas fontes.
+- Persiste cada task como arquivo JSON individual em workspace_output/coder/tasks/.
 - O agente NÃO implementa código. NÃO define requisitos de negócio. Apenas contextualiza, enriquece e empacota para consumo do Coder.
 """
 instruction = (
@@ -21,63 +21,131 @@ instruction = (
 - Você APENAS contextualiza, enriquece e empacota requisitos para consumo do Coder.
 
 # ENTRADA
-- Os artefatos necessários para gerar as tasks serão lidos diretamente do workspace nos Passos 1 e 2 do fluxo obrigatório.
-- Não é necessário receber dados via state ou mensagem de entrada.
-- Se os artefatos não forem encontrados ou os mínimos obrigatórios estiverem ausentes, chame tool_gerar_doubt_artifact e encerre sem gerar nenhuma task.
+O orquestrador repassa no texto de entrada os manifestos das fases anteriores
+no seguinte formato:
+ 
+  ## phase: requirements (status: ok|blocked|partial)
+  summary: <resumo>
+  artifacts:
+    - tipo=HU id=HU-001 path=requirements/HUs/HU-001.md
+    - tipo=RF id=RF-001 path=requirements/RFs/RF-001.md
+  doubts:
+    - id=D-001 severidade=alta bloqueante=True path=requirements/doubts/D-001.md
+ 
+Extraia essas informações do texto antes de prosseguir.
+Se os manifestos indicarem bloqueio ou os artefatos mínimos estiverem ausentes, chame tool_gerar_doubt_artifact e encerre sem gerar nenhuma task.
 
 # FLUXO OBRIGATÓRIO
 
+## Passo 0 — Verificar status dos manifestos recebidos
+Leia o manifesto de requirements no texto recebido do orquestrador.
+ 
+- Se não encontrar o manifesto de requirements no texto:
+  * Chame tool_gerar_doubt_artifact informando:
+    - titulo: 'Manifesto de requirements não encontrado'
+    - fase_bloqueada: 'requirements'
+    - descricao: 'O orquestrador não repassou o manifesto de requirements no prompt.'
+    - acao_necessaria: 'A fase requirements deve ter concluído antes de continuar'
+    - subdir: 'coder'
+  * Chame tool_emitir_manifesto_bloqueado informando:
+    - motivo: descreva o bloqueio encontrado
+  * Chame aguardar_resolucao_bloqueio informando:
+    - fase_bloqueada: '...'
+    - motivo: descreva o bloqueio encontrado
+    - acao_necessaria: '...'
+  * PARE IMEDIATAMENTE. Não gere nenhuma task.
+ 
+- Se status do manifesto de requirements == "blocked":
+  * Chame tool_gerar_doubt_artifact informando:
+    - titulo: 'Fase de requisitos bloqueada'
+    - fase_bloqueada: 'requirements'
+    - descricao: use o campo summary do manifesto para descrever o bloqueio
+    - acao_necessaria: 'A fase de requisitos deve ser reprocessada antes de continuar'
+    - subdir: 'coder'
+  * Chame tool_emitir_manifesto_bloqueado informando:
+    - motivo: descreva o bloqueio encontrado
+  * Chame aguardar_resolucao_bloqueio informando:
+    - fase_bloqueada: '...'
+    - motivo: descreva o bloqueio encontrado
+    - acao_necessaria: '...'
+  * PARE IMEDIATAMENTE. Não gere nenhuma task.
+ 
+- Se status == "partial":
+  * Registre no summary final que há pendências não-bloqueantes na fase de requisitos.
+  * Continue normalmente.
+
 ## Passo 1 — Ler artefatos de requisitos
-- Chame tool_ler_requirements.
-- Esta tool lê todos os artefatos da pasta requirements/ no workspace: HUs, RFs, RNFs, casos de uso, regras de negócio e glossário.
+- Extraia a lista de artifacts do manifesto de requirements no texto recebido.
+  Cada artifact aparece no formato: tipo=XX id=XX path=XX
+  Extraia apenas o valor após "path=" de cada linha de artifact.
+- Monte uma lista JSON simples com os paths de todos os artefatos extraídos do manifesto.
+  Use APENAS forward slashes (/) nos paths — nunca barras invertidas (\).
+  Formato obrigatório: ["requirements/HUs/HU-001.md", "requirements/RFs/RF-001.md"]
+  O argumento deve ser uma string JSON válida e completa — sem texto adicional antes ou depois.
+- Chame tool_ler_requirements passando APENAS essa string JSON como argumento paths_json.
 - Se retornar sucesso=False OU artefatos_minimos_presentes=False:
-* Chame tool_gerar_doubt_artifact informando:
-- titulo: se sucesso=False use 'Pasta de requisitos ausente ou inacessível' senão use 'Artefatos mínimos de requisitos ausentes'
-- fase_bloqueada: 'requirements'
-- descricao: se sucesso=False use o campo erro do retorno senão use uma string com os itens de artefatos_minimos_ausentes (ex.: juntar com '; ')
-- acao_necessaria: 'A fase requirements deve ser reprocessada antes de continuar'
-* PARE IMEDIATAMENTE. Não gere nenhuma task.
+  * Chame tool_gerar_doubt_artifact informando:
+    - titulo: 'Artefatos mínimos de requisitos ausentes'
+    - fase_bloqueada: 'requirements'
+    - descricao: use o campo artefatos_minimos_ausentes do retorno
+    - acao_necessaria: 'A fase requirements deve ser reprocessada antes de continuar'
+    - subdir: 'coder'
+  * Chame tool_emitir_manifesto_bloqueado informando:
+    - motivo: descreva o bloqueio encontrado
+  * Chame aguardar_resolucao_bloqueio informando:
+    - fase_bloqueada: '...'
+    - motivo: descreva o bloqueio encontrado
+    - acao_necessaria: '...'
+  * PARE IMEDIATAMENTE. Não gere nenhuma task.
 
 ## Passo 2 — Ler artefatos de design
-- Chame tool_ler_design.
-- Esta tool lê todos os artefatos da pasta design/ no workspace: diagramas Mermaid, relatórios de arquitetura mínima e análises técnicas por HU.
+- Chame tool_ler_design passando tem_hu=True se tool_ler_requirements retornou tem_hu=True, senão tem_hu=False.
+- A tool lê workspace/design/ diretamente (fallback enquanto o Time 2 não produz manifesto).
 - Se retornar sucesso=False OU artefatos_minimos_presentes=False:
-* Chame tool_gerar_doubt_artifact informando:
-- titulo: se sucesso=False use 'Pasta de design ausente ou inacessível' senão use 'Análise técnica ausente no workspace de design'
-- fase_bloqueada: 'design'
-- descricao: se sucesso=False use o campo erro do retorno senão use o campo artefatos_minimos_ausentes do retorno
-- acao_necessaria: 'A fase design deve ser reprocessada antes de continuar'
-* PARE IMEDIATAMENTE. Não gere nenhuma task.
+  * Chame tool_gerar_doubt_artifact informando:
+    - titulo: se sucesso=False use 'Pasta de design ausente ou inacessível' senão use 'Análise técnica ausente no workspace de design'
+    - fase_bloqueada: 'design'
+    - descricao: use o campo erro do retorno
+    - acao_necessaria: 'A fase design deve ser reprocessada antes de continuar'
+    - subdir: 'coder'
+  * Chame tool_emitir_manifesto_bloqueado informando:
+    - motivo: descreva o bloqueio encontrado
+  * Chame aguardar_resolucao_bloqueio informando:
+    - fase_bloqueada: 'design'
+    - motivo: descreva o bloqueio encontrado
+    - acao_necessaria: 'A fase design deve ser reprocessada antes de continuar'
+  * PARE IMEDIATAMENTE. Não gere nenhuma task.
+- Se retornar inconsistencia_detectada=True:
+  * Chame tool_gerar_doubt_artifact informando:
+    - titulo: 'Inconsistência entre design e requisitos'
+    - fase_bloqueada: 'requirements'
+    - descricao: 'O Time 2 produziu análises técnicas por HU mas não existem HUs nos artefatos de requirements.'
+    - acao_necessaria: 'O Time 1 deve reprocessar e persistir as HUs antes de continuar'
+    - subdir: 'coder'
+  * Chame tool_emitir_manifesto_bloqueado informando:
+    - motivo: 'Inconsistência detectada: análise técnica por HU existe no design mas não há HUs em requirements'
+  * Chame aguardar_resolucao_bloqueio informando:
+    - fase_bloqueada: 'requirements'
+    - motivo: 'Inconsistência entre design e requirements'
+    - acao_necessaria: 'O Time 1 deve reprocessar e persistir as HUs antes de continuar'
+  * PARE IMEDIATAMENTE. Não gere nenhuma task.
 
 ## Passo 2.5 — Verificar consistência entre requisitos e design
-Com os artefatos de ambas as pastas carregados, verifique os três cenários abaixo
-antes de prosseguir para a geração de tasks:
+Com os artefatos de ambas as pastas carregados, verifique os três cenários:
  
-### Cenário 1 — Inconsistência entre times (BLOQUEANTE)
-Se existirem arquivos analise_tecnica_HU-*.md em design/ MAS não existir
-a pasta HUs/ em requirements/:
-* Chame tool_gerar_doubt_artifact informando:
-- titulo: 'Inconsistência entre design e requisitos'
-- fase_bloqueada: 'requirements'
-- descricao: 'O Time 2 produziu análises técnicas por HU mas não existem HUs persistidas em requirements/HUs/. Provável erro de persistência do Time 1.'
-- acao_necessaria: 'O Time 1 deve reprocessar e persistir as HUs antes de continuar'
-* PARE IMEDIATAMENTE. Não gere nenhuma task.
+### Cenário 1 — Pedido técnico puro sem HU (CASO DE EXCEÇÃO VÁLIDO)
+Se TODOS os RFs tiverem "HU Pai" ausente ou "_(não vinculado)_" E não existirem arquivos analise_tecnica_HU-*.md nos artefatos de design:
+    * É um pedido técnico puro — cenário válido e esperado.
+    * Gere tasks usando o RF e os demais artefatos disponíveis relevantes.
+    * design_refs: deixe como lista vazia.
+    * Não gere Doubt Artifact.
  
-### Cenário 2 — Pedido técnico puro sem HU (CASO DE EXCEÇÃO VÁLIDO)
-Se TODOS os RFs tiverem "HU Pai" ausente ou "_(não vinculado)_"
-E não existirem arquivos analise_tecnica_HU-*.md em design/:
-* É um pedido técnico puro — cenário válido e esperado.
-* Gere tasks usando o RF e os demais artefatos persistidos que sejam relevantes para cada task.
-* design_refs: deixe como lista vazia — não há artefatos de design vinculados a HUs neste cenário.
-* Não gere Doubt Artifact.
- 
-### Cenário 3 — RF transversal legítimo (SEM BLOQUEIO)
-Se ALGUNS RFs tiverem "HU Pai" ausente ou "_(não vinculado)_"
-MAS existirem HUs e analise_tecnica_HU-*.md no workspace:
-* Os RFs órfãos são requisitos transversais — cenário válido.
-* Para cada RF órfão, gere a task usando o RF e os demais artefatos persistidos que sejam relevantes para a task específica.
-* design_refs: analise criteriosamente se alguma analise_tecnica_HU-*.md tem relação com o contexto do RF antes de referenciar. Se nenhuma tiver relação, deixe design_refs como lista vazia. Não referencia por referenciar — isso gera alucinação.
-* Não gere Doubt Artifact.
+### Cenário 2 — RF transversal legítimo (SEM BLOQUEIO)
+Se ALGUNS RFs tiverem "HU Pai" ausente ou "_(não vinculado)_" MAS existirem HUs e analise_tecnica_HU-*.md no workspace:
+    * Os RFs órfãos são requisitos transversais — cenário válido.
+    * Para cada RF órfão, gere a task usando os artefatos disponíveis relevantes.
+    * design_refs: analise criteriosamente antes de referenciar. Se nenhuma análise tiver relação real com o RF, deixe design_refs como lista vazia.
+    * Não gere Doubt Artifact.
 
 ## Passo 3 — Extrair Contexto Macro
 Com todos os artefatos carregados de ambas as pastas, identifique e sintetize:
@@ -87,36 +155,41 @@ Com todos os artefatos carregados de ambas as pastas, identifique e sintetize:
 - global_rules: restrições arquiteturais derivadas das análises técnicas e relatórios de arquitetura mínima, neutras quanto à tecnologia. Máximo 4 regras. Se não houver, use ['Seguir padrões do projeto'].
 
 ## Passo 4 — Decompor em Tasks Contextualizadas
-Os artefatos mínimos já foram validados nos Passos 1 e 2.
+Os artefatos mínimos já foram validados.
 Para CADA requisito funcional (RF) encontrado nos artefatos de requisitos, gere uma Task contendo:
+
 - **id**: formato TASK-XXX (sequencial, ex.: TASK-001, TASK-002).
+
 - **type**: categoria da task, coerente com o product_type. Vocabulário recomendado (aberto): component | interface | data | infra | test | docs. Outro valor é permitido quando o produto exigir — não force a task em uma categoria web se o produto não for web.
+
 - **complexity**: estime como low | medium | high com base nos RFs e na análise técnica do time de design.
-- **description**: Reescreva orientada à implementação combinando a description do RF com as decisões técnicas do contexto de design disponível. Deve ser clara o suficiente para o Coder saber EXATAMENTE o que codificar.
+
+- **description**: Reescreva orientada à implementação combinando a description do RF com as decisões técnicas do contexto de design disponível.
+
 - **business_rules**: extraia regras de negócio específicas desta task. Se não houver regras explícitas, deixe a lista vazia.
-- **acceptance_criteria**: derive APENAS a partir das fontes que existirem nos artefatos lidos:
+
+- **acceptance_criteria**: derive APENAS a partir das fontes que existirem:
     1. description do próprio RF (obrigatório)
-    2. acceptance_criteria da UserStory vinculada ao RF via "HU Pai" (use somente se a HU existir no workspace)
-    3. description dos RNFs relevantes para este RF (use somente se existirem RNFs no workspace)
-    4. Decisões de arquitetura da análise técnica lida do workspace (use somente se existir a análise técnica no workspace)
-    - NUNCA invente critérios baseados em suposições - use apenas o que foi lido do workspace.
-    - Se apenas o RF estiver disponível, derive os critérios somente a partir dele.
+    2. acceptance_criteria da UserStory vinculada ao RF via "HU Pai" (use somente se a HU existir nos artefatos)
+    3. description dos RNFs relevantes para este RF (use somente se existirem RNFs nos artefatos)
+    4. Decisões de arquitetura da análise técnica disponível (use somente se existirem artefatos de design relevantes)
+    - NUNCA invente critérios baseados em suposições.
     - Cada critério deve ser testável pelo Time de QA.
     - Formato: verbo no infinitivo + condição + resultado esperado.
     - Derive do produto real (product_type); NÃO presuma HTTP/status code se o produto não for um serviço web.
     - Exemplo (web): 'Retornar status 401 quando credenciais forem inválidas'
     - Exemplo (não-web): 'Encerrar com exit code 1 quando o arquivo de entrada não existir' (CLI) ou 'Lançar ValueError quando o argumento for negativo' (library)
+
 - **contract**: defina as fronteiras com base nos artefatos de design:
     - inputs: arquivos ou módulos que o Coder pode LER mas NÃO modificar.
     - outputs: arquivos que o Coder deve CRIAR ou MODIFICAR.
     - interfaces: pontos de contato públicos que devem ser respeitados, conforme o product_type (rota HTTP, comando CLI, assinatura de função/módulo, evento…). Extraia dos diagramas Mermaid quando houver; deixe vazio se não houver artefatos de design relevantes.
+
 - **requirement_id**: ID do RF de origem (ex.: RF-001).
-    - Garante a rastreabilidade explícita até os artefatos do Time de requisitos.
-- **design_refs**: paths dos artefatos de design lidos do workspace que são relevantes para este RF específico.
+
+- **design_refs**: paths dos artefatos de design relevantes para este RF.
     - Consulte o Cenário definido no Passo 2.5 para determinar o preenchimento:
-    * Cenário 2: lista vazia (pedido técnico puro sem HU)
-    * Cenário 3: somente artefatos com relação real ao contexto do RF
-    * RFs com HU associada: artefatos correspondentes à HU vinculada
+    - Não referencia por referenciar — isso gera alucinação.
 
 ## Passo 5 — Persistir no Workspace
 Após gerar todas as tasks, chame tool_salvar_task para cada uma individualmente. Forneça o task_id e o JSON serializado da task.
@@ -131,11 +204,11 @@ Retorne o JSON completo conforme o schema do sistema, contendo:
 - Cada task deve ser autocontida: o Coder deve conseguir executá-la sem
   precisar consultar outras tasks ou outros documentos.
 - requirement_id é obrigatório em toda task.
-- design_refs pode ser lista vazia nos Cenários 2 e 3 quando não houver artefatos de design relevantes — não referencia por referenciar.
-- Os acceptance_criteria devem derivar apenas das fontes disponíveis no workspace, nunca invente critérios sem base nos artefatos lidos.
+- design_refs pode ser lista vazia nos Cenários 1 e 2 quando não houver artefatos de design relevantes.
+- Os acceptance_criteria devem derivar apenas das fontes disponíveis, nunca invente critérios sem base nos artefatos lidos.
 - O macro_context deve ser conciso (no máximo 4 regras globais).
 - Limite de 8 tasks por execução. Se houver mais de 8 RFs, priorize as bloqueantes e agrupe as relacionadas.
-- Cada task deve caber em aproximadamente 1500 tokens para otimizar a janela de contexto do Coder.
+- Cada task deve caber em aproximadamente 1500 tokens.
 
 # SAÍDA OBRIGATÓRIA
 Responda APENAS com JSON válido conforme o schema definido pelo sistema.

--- a/adk/src/agents/workflow_coding_review/context_engineer/prompt.py
+++ b/adk/src/agents/workflow_coding_review/context_engineer/prompt.py
@@ -192,7 +192,7 @@ Para CADA requisito funcional (RF) encontrado nos artefatos de requisitos, gere 
     - Não referencia por referenciar — isso gera alucinação.
 
 ## Passo 5 — Persistir no Workspace
-Após gerar todas as tasks, chame tool_salvar_task para cada uma individualmente. Forneça o task_id e o JSON serializado da task.
+Após gerar todas as tasks, chame tool_salvar_task_cr para cada uma individualmente. Forneça o task_id e o JSON serializado da task.
 Em seguida, chame tool_salvar_macro_context_cr UMA vez, passando o JSON serializado do macro_context (summary, product_type, tech_stack, global_rules). Este passo é obrigatório: os estágios downstream (executor/harness) dependem do product_type persistido para escolher a superfície de execução correta.
 
 ## Passo 6 — Retornar Saída Estruturada

--- a/adk/src/agents/workflow_coding_review/context_engineer/prompt.py
+++ b/adk/src/agents/workflow_coding_review/context_engineer/prompt.py
@@ -8,7 +8,7 @@ workspace_output/coder/tasks/ (consolidado sob coder/).
 
 description = """
 - Agente de engenharia de contexto para o pipeline SDLC.
-- Consome o manifesto de requiriments repassado pelo orquestrador para gerar tarefas de codificação contextualizadas (Context Windows), enriquecidas com rastreabilidade explícita até os requisitos e artefatos de design, e critérios de aceitação derivados de múltiplas fontes.
+- Consome o manifesto de requirements repassado pelo orquestrador para gerar tarefas de codificação contextualizadas (Context Windows), enriquecidas com rastreabilidade explícita até os requisitos e artefatos de design, e critérios de aceitação derivados de múltiplas fontes.
 - Persiste cada task como arquivo JSON individual em workspace_output/coder/tasks/.
 - O agente NÃO implementa código. NÃO define requisitos de negócio. Apenas contextualiza, enriquece e empacota para consumo do Coder.
 """

--- a/adk/src/agents/workflow_coding_review/manifest.py
+++ b/adk/src/agents/workflow_coding_review/manifest.py
@@ -1,0 +1,224 @@
+"""Emissor determinístico do Manifesto de Fase — Codificação (Time 4).
+
+Padrão: after_agent_callback determinístico, zero LLM — alinhado ao
+emit_requirements_manifest do Time 1 (PR #320), adaptado para o
+workspace e fluxo de validação do pipeline coding_review.
+
+Diferença em relação ao Time 1: a fase de codificação tem uma etapa de
+revisão explícita (cr_reviewer) cujo veredicto (APROVADO / BLOQUEADO)
+entra na derivação de status, além dos Doubt_Artifacts gerados pelo
+context engineer.
+
+Layout do workspace (ver shared/workspace.py::AGENT_DIRS):
+
+    workspace_output/coder/src/app/      → tipo "codigo"
+    workspace_output/coder/src/tests/    → tipo "teste"
+    workspace_output/coder/src/          → tipo "config"  (Dockerfile, etc.)
+    workspace_output/coder/review/       → tipo "revisao"
+    workspace_output/coder/**/Doubt_*    → doubts
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from shared.workspace import get_agent_workspace, get_workspace_root
+
+if TYPE_CHECKING:
+    from google.adk.agents.callback_context import CallbackContext
+else:
+    CallbackContext = Any
+
+logger = logging.getLogger(__name__)
+
+PHASE_NAME = "coding"
+STATE_KEY = "coding_manifest"
+
+_REVIEW_PASS_MARKERS = ("## Status: APROVADO", "Status: APROVADO")
+_REVIEW_FAIL_MARKERS = ("## Status: BLOQUEADO", "Status: BLOQUEADO")
+
+_CONFIG_FILES = {
+    "requirements.txt", "Dockerfile", "docker-compose.yml",
+    "docker-compose.yaml", "conftest.py", ".dockerignore",
+    "pyproject.toml", "setup.py", "setup.cfg",
+}
+
+_IGNORED = {"manifest.json", ".ai4se_workspace", "io_operations.log"}
+_IGNORED_SUFFIXES = {".pyc", ".pyo"}
+
+
+def _scan_artifacts(coder_ws: Path, ws_root: Path) -> list[dict]:
+    """Varre o workspace de coding e classifica artefatos por tipo."""
+    artifacts: list[dict] = []
+
+    app_dir = coder_ws / "src" / "app"
+    if app_dir.exists():
+        for f in sorted(app_dir.rglob("*.py")):
+            if "__pycache__" not in f.parts and f.name not in _IGNORED:
+                artifacts.append({
+                    "tipo": "codigo",
+                    "id": f.stem,
+                    "path": str(f.relative_to(ws_root)).replace("\\", "/"),
+                })
+
+    tests_dir = coder_ws / "src" / "tests"
+    if tests_dir.exists():
+        for f in sorted(tests_dir.rglob("*.py")):
+            if "__pycache__" not in f.parts and f.name not in _IGNORED:
+                artifacts.append({
+                    "tipo": "teste",
+                    "id": f.stem,
+                    "path": str(f.relative_to(ws_root)).replace("\\", "/"),
+                })
+
+    src = coder_ws / "src"
+    if src.exists():
+        for f in sorted(src.iterdir()):
+            if f.is_file() and f.name in _CONFIG_FILES:
+                artifacts.append({
+                    "tipo": "config",
+                    "id": f.stem,
+                    "path": str(f.relative_to(ws_root)).replace("\\", "/"),
+                })
+
+    review_dir = coder_ws / "review"
+    if review_dir.exists():
+        for f in sorted(review_dir.iterdir()):
+            if f.is_file() and f.name not in _IGNORED and f.suffix not in _IGNORED_SUFFIXES:
+                artifacts.append({
+                    "tipo": "revisao",
+                    "id": f.stem,
+                    "path": str(f.relative_to(ws_root)).replace("\\", "/"),
+                })
+
+    return artifacts
+
+
+def _scan_doubts(coder_ws: Path, ws_root: Path) -> list[dict]:
+    """Varre o workspace de coding por Doubt_Artifact_*.md.
+
+    O cr_context_engineer grava doubts em coder/tasks/ via
+    tool_gerar_doubt_artifact_adk. O marcador de bloqueante é
+    '**Bloqueante:** Sim' (mesmo padrão do Time 1).
+    """
+    doubts: list[dict] = []
+    for f in sorted(coder_ws.rglob("Doubt_Artifact_*.md")):
+        try:
+            text = f.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        bloqueante = "**Bloqueante:** Sim" in text
+        doubts.append({
+            "id": f.stem,
+            "severidade": "alta" if bloqueante else "media",
+            "bloqueante": bloqueante,
+            "path": str(f.relative_to(ws_root)).replace("\\", "/"),
+        })
+    return doubts
+
+
+def _validation_verdict(coder_ws: Path) -> str:
+    """Lê o veredicto do cr_reviewer em coder/review/.
+
+    Retorna 'pass', 'fail' ou 'absent'. Exclusivo da fase de coding —
+    o reviewer emite um relatório explícito que vai além dos doubts.
+    """
+    review_dir = coder_ws / "review"
+    if not review_dir.exists():
+        return "absent"
+
+    saw_pass = False
+    for f in review_dir.iterdir():
+        if not f.is_file() or f.name in _IGNORED or f.suffix in _IGNORED_SUFFIXES:
+            continue
+        try:
+            content = f.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if any(m in content for m in _REVIEW_FAIL_MARKERS):
+            return "fail"
+        if any(m in content for m in _REVIEW_PASS_MARKERS):
+            saw_pass = True
+
+    return "pass" if saw_pass else "absent"
+
+
+def _derive_status(artifacts: list[dict], doubts: list[dict], validation: str) -> str:
+    """Deriva o status da fase coding.
+
+    Precedência:
+    1. Doubt bloqueante            → blocked
+    2. Nenhum artefato de código   → blocked
+    3. Doubt não-bloqueante        → partial
+    4. Reviewer aprovado           → ok
+    5. Reviewer falhou / ausente   → partial
+    """
+    if any(d["bloqueante"] for d in doubts):
+        return "blocked"
+    code_artifacts = [a for a in artifacts if a["tipo"] == "codigo"]
+    if not code_artifacts:
+        return "blocked"
+    if doubts:
+        return "partial"
+    if validation == "pass":
+        return "ok"
+    return "partial"
+
+
+def _build_summary(artifacts: list[dict], doubts: list[dict], validation: str) -> str:
+    counts: dict[str, int] = {}
+    for a in artifacts:
+        counts[a["tipo"]] = counts.get(a["tipo"], 0) + 1
+    partes = (
+        ", ".join(f"{n} {tipo}(s)" for tipo, n in sorted(counts.items()))
+        or "nenhum artefato"
+    )
+    base = f"Fase de codificação concluída. {partes}. Revisão: {validation}."
+    if doubts:
+        n_bloq = sum(1 for d in doubts if d["bloqueante"])
+        base += f" {len(doubts)} dúvida(s) ({n_bloq} bloqueante(s))."
+    return base
+
+
+def emit_coding_manifest(callback_context: CallbackContext) -> None:
+    """after_agent_callback — emite o manifesto da fase de codificação.
+
+    Grava em callback_context.state["coding_manifest"] (handoff in-memory
+    para o orquestrador) e persiste coding/manifest.json no workspace para
+    rastreabilidade e consumo pelo pipeline de QA.
+
+    Retorna None para não sobrescrever a saída do agente (contrato ADK).
+    """
+    try:
+        ws_root = get_workspace_root()
+        coder_ws = get_agent_workspace("coder")
+
+        artifacts  = _scan_artifacts(coder_ws, ws_root)
+        doubts     = _scan_doubts(coder_ws, ws_root)
+        validation = _validation_verdict(coder_ws)
+        status     = _derive_status(artifacts, doubts, validation)
+
+        manifest: dict = {
+            "phase":     PHASE_NAME,
+            "status":    status,
+            "artifacts": artifacts,
+            "doubts":    doubts,
+            "summary":   _build_summary(artifacts, doubts, validation),
+        }
+
+        callback_context.state[STATE_KEY] = manifest
+
+        manifest_path = ws_root / "coding" / "manifest.json"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        logger.info(
+            "[MANIFEST] coding → %s | %d artefato(s) | %d dúvida(s) | revisão: %s",
+            status, len(artifacts), len(doubts), validation,
+        )
+    except Exception as exc:
+        logger.warning("[MANIFEST] Falha ao emitir manifesto de coding: %s", exc)

--- a/adk/src/agents/workflow_coding_review/manifest.py
+++ b/adk/src/agents/workflow_coding_review/manifest.py
@@ -98,12 +98,13 @@ def _scan_artifacts(coder_ws: Path, ws_root: Path) -> list[dict]:
 def _scan_doubts(coder_ws: Path, ws_root: Path) -> list[dict]:
     """Varre o workspace de coding por Doubt_Artifact_*.md.
 
-    O cr_context_engineer grava doubts em coder/tasks/ via
-    tool_gerar_doubt_artifact_adk. O marcador de bloqueante é
+    tool_gerar_doubt_artifact_adk escreve em ws_root/Doubt_Artifact_*.md
+    (raiz do workspace), não dentro de coder/. O scan parte de ws_root
+    para cobrir ambos os casos. O marcador de bloqueante é
     '**Bloqueante:** Sim' (mesmo padrão do Time 1).
     """
     doubts: list[dict] = []
-    for f in sorted(coder_ws.rglob("Doubt_Artifact_*.md")):
+    for f in sorted(ws_root.rglob("Doubt_Artifact_*.md")):
         try:
             text = f.read_text(encoding="utf-8", errors="ignore")
         except OSError:

--- a/adk/src/agents/workflow_coding_review/manifest.py
+++ b/adk/src/agents/workflow_coding_review/manifest.py
@@ -15,6 +15,7 @@ Layout do workspace (ver shared/workspace.py::AGENT_DIRS):
     workspace_output/coder/src/tests/    → tipo "teste"
     workspace_output/coder/src/          → tipo "config"  (Dockerfile, etc.)
     workspace_output/coder/review/       → tipo "revisao"
+    workspace_output/coder/tasks/        → tipo "task"
     workspace_output/coder/**/Doubt_*    → doubts
 """
 
@@ -38,56 +39,75 @@ STATE_KEY = "coding_manifest"
 _REVIEW_PASS_MARKERS = ("## Status: APROVADO", "Status: APROVADO")
 _REVIEW_FAIL_MARKERS = ("## Status: BLOQUEADO", "Status: BLOQUEADO")
 
-_CONFIG_FILES = {
-    "requirements.txt", "Dockerfile", "docker-compose.yml",
-    "docker-compose.yaml", "conftest.py", ".dockerignore",
-    "pyproject.toml", "setup.py", "setup.cfg",
-}
-
 _IGNORED = {"manifest.json", ".ai4se_workspace", "io_operations.log"}
 _IGNORED_SUFFIXES = {".pyc", ".pyo"}
 
 
 def _scan_artifacts(coder_ws: Path, ws_root: Path) -> list[dict]:
-    """Varre o workspace de coding e classifica artefatos por tipo."""
+    """Varre o workspace de coding e classifica artefatos por tipo.
+    Cataloga todos os arquivos gerados pelo coder — não apenas .py ou
+    arquivos de configuração pré-definidos. O tipo é determinado pela
+    subpasta dentro de src/:
+      - app/    → codigo
+      - tests/  → teste
+      - demais  → config
+    """
     artifacts: list[dict] = []
-
-    app_dir = coder_ws / "src" / "app"
-    if app_dir.exists():
-        for f in sorted(app_dir.rglob("*.py")):
-            if "__pycache__" not in f.parts and f.name not in _IGNORED:
-                artifacts.append({
-                    "tipo": "codigo",
-                    "id": str(f.relative_to(app_dir).with_suffix("")).replace("\\", "/"),
-                    "path": str(f.relative_to(ws_root)).replace("\\", "/"),
-                })
-
-    tests_dir = coder_ws / "src" / "tests"
-    if tests_dir.exists():
-        for f in sorted(tests_dir.rglob("*.py")):
-            if "__pycache__" not in f.parts and f.name not in _IGNORED:
-                artifacts.append({
-                    "tipo": "teste",
-                    "id": str(f.relative_to(tests_dir).with_suffix("")).replace("\\", "/"),
-                    "path": str(f.relative_to(ws_root)).replace("\\", "/"),
-                })
 
     src = coder_ws / "src"
     if src.exists():
-        for f in sorted(src.iterdir()):
-            if f.is_file() and f.name in _CONFIG_FILES:
-                artifacts.append({
-                    "tipo": "config",
-                    "id": f.name,
-                    "path": str(f.relative_to(ws_root)).replace("\\", "/"),
-                })
+        for f in sorted(src.rglob("*")):
+            if (
+                not f.is_file()
+                or "__pycache__" in f.parts
+                or f.name in _IGNORED
+                or f.suffix in _IGNORED_SUFFIXES
+            ):
+                continue
+ 
+            partes = f.relative_to(src).parts
+            subdir = partes[0] if partes else ""
+ 
+            if subdir == "app":
+                tipo = "codigo"
+                id_val = str(
+                    f.relative_to(src / "app").with_suffix("")
+                ).replace("\\", "/")
+            elif subdir == "tests":
+                tipo = "teste"
+                id_val = str(
+                    f.relative_to(src / "tests").with_suffix("")
+                ).replace("\\", "/")
+            else:
+                tipo = "config"
+                id_val = f.name
+ 
+            artifacts.append({
+                "tipo": tipo,
+                "id": id_val,
+                "path": str(f.relative_to(ws_root)).replace("\\", "/"),
+            })
 
     review_dir = coder_ws / "review"
     if review_dir.exists():
         for f in sorted(review_dir.iterdir()):
-            if f.is_file() and f.name not in _IGNORED and f.suffix not in _IGNORED_SUFFIXES:
+            if (
+                f.is_file()
+                and f.name not in _IGNORED
+                and f.suffix not in _IGNORED_SUFFIXES
+            ):
                 artifacts.append({
                     "tipo": "revisao",
+                    "id": f.stem,
+                    "path": str(f.relative_to(ws_root)).replace("\\", "/"),
+                })
+
+    tasks_dir = coder_ws / "tasks"
+    if tasks_dir.exists():
+        for f in sorted(tasks_dir.glob("*.json")):
+            if f.name not in _IGNORED:
+                artifacts.append({
+                    "tipo": "task",
                     "id": f.stem,
                     "path": str(f.relative_to(ws_root)).replace("\\", "/"),
                 })
@@ -101,8 +121,7 @@ def _scan_doubts(coder_ws: Path, ws_root: Path) -> list[dict]:
     tool_gerar_doubt_artifact_adk escreve em ws_root/Doubt_Artifact_*.md
     (raiz do workspace). O scan cobre a raiz (não recursivo) e o interior
     de coder/ (recursivo), evitando capturar doubts de outras fases
-    (requirements/, design/, etc.). O marcador de bloqueante é
-    '**Bloqueante:** Sim' (mesmo padrão do Time 1).
+    (requirements/, design/, etc.).
     """
     candidates = set(ws_root.glob("Doubt_Artifact_*.md"))
     candidates |= set(coder_ws.rglob("Doubt_Artifact_*.md"))
@@ -127,8 +146,7 @@ def _scan_doubts(coder_ws: Path, ws_root: Path) -> list[dict]:
 def _validation_verdict(coder_ws: Path) -> str:
     """Lê o veredicto do cr_reviewer em coder/review/.
 
-    Retorna 'pass', 'fail' ou 'absent'. Exclusivo da fase de coding —
-    o reviewer emite um relatório explícito que vai além dos doubts.
+    Retorna 'pass', 'fail' ou 'absent'.
     """
     review_dir = coder_ws / "review"
     if not review_dir.exists():
@@ -150,7 +168,11 @@ def _validation_verdict(coder_ws: Path) -> str:
     return "pass" if saw_pass else "absent"
 
 
-def _derive_status(artifacts: list[dict], doubts: list[dict], validation: str) -> str:
+def _derive_status(
+    artifacts: list[dict],
+    doubts: list[dict],
+    validation: str,
+) -> str:
     """Deriva o status da fase coding.
 
     Precedência:
@@ -172,7 +194,11 @@ def _derive_status(artifacts: list[dict], doubts: list[dict], validation: str) -
     return "partial"
 
 
-def _build_summary(artifacts: list[dict], doubts: list[dict], validation: str) -> str:
+def _build_summary(
+    artifacts: list[dict],
+    doubts: list[dict],
+    validation: str,
+) -> str:
     counts: dict[str, int] = {}
     for a in artifacts:
         counts[a["tipo"]] = counts.get(a["tipo"], 0) + 1
@@ -191,7 +217,7 @@ def emit_coding_manifest(callback_context: CallbackContext) -> None:
     """after_agent_callback — emite o manifesto da fase de codificação.
 
     Grava em callback_context.state["coding_manifest"] (handoff in-memory
-    para o orquestrador) e persiste coding/manifest.json no workspace para
+    para o orquestrador) e persiste coder/manifest.json no workspace para
     rastreabilidade e consumo pelo pipeline de QA.
 
     Retorna None para não sobrescrever a saída do agente (contrato ADK).
@@ -205,11 +231,6 @@ def emit_coding_manifest(callback_context: CallbackContext) -> None:
         validation = _validation_verdict(coder_ws)
         status     = _derive_status(artifacts, doubts, validation)
 
-        session_id = (
-            getattr(getattr(callback_context, "session", None), "id", None)
-            or getattr(callback_context, "session_id", None)
-            or callback_context.state.get("session_id")
-        )
 
         manifest: dict = {
             "phase":      PHASE_NAME,
@@ -217,12 +238,11 @@ def emit_coding_manifest(callback_context: CallbackContext) -> None:
             "artifacts":  artifacts,
             "doubts":     doubts,
             "summary":    _build_summary(artifacts, doubts, validation),
-            "session_id": session_id,
         }
 
         callback_context.state[STATE_KEY] = manifest
 
-        manifest_path = ws_root / "coding" / "manifest.json"
+        manifest_path = coder_ws / "manifest.json"
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
         manifest_path.write_text(
             json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",

--- a/adk/src/agents/workflow_coding_review/manifest.py
+++ b/adk/src/agents/workflow_coding_review/manifest.py
@@ -199,12 +199,19 @@ def emit_coding_manifest(callback_context: CallbackContext) -> None:
         validation = _validation_verdict(coder_ws)
         status     = _derive_status(artifacts, doubts, validation)
 
+        session_id = (
+            getattr(getattr(callback_context, "session", None), "id", None)
+            or getattr(callback_context, "session_id", None)
+            or callback_context.state.get("session_id")
+        )
+
         manifest: dict = {
-            "phase":     PHASE_NAME,
-            "status":    status,
-            "artifacts": artifacts,
-            "doubts":    doubts,
-            "summary":   _build_summary(artifacts, doubts, validation),
+            "phase":      PHASE_NAME,
+            "status":     status,
+            "artifacts":  artifacts,
+            "doubts":     doubts,
+            "summary":    _build_summary(artifacts, doubts, validation),
+            "session_id": session_id,
         }
 
         callback_context.state[STATE_KEY] = manifest

--- a/adk/src/agents/workflow_coding_review/manifest.py
+++ b/adk/src/agents/workflow_coding_review/manifest.py
@@ -28,7 +28,7 @@ from shared.workspace import get_agent_workspace, get_workspace_root
 if TYPE_CHECKING:
     from google.adk.agents.callback_context import CallbackContext
 else:
-    CallbackContext = Any
+    CallbackContext = Any  # type: ignore[misc,assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ def _scan_artifacts(coder_ws: Path, ws_root: Path) -> list[dict]:
             if "__pycache__" not in f.parts and f.name not in _IGNORED:
                 artifacts.append({
                     "tipo": "codigo",
-                    "id": f.stem,
+                    "id": str(f.relative_to(app_dir).with_suffix("")).replace("\\", "/"),
                     "path": str(f.relative_to(ws_root)).replace("\\", "/"),
                 })
 
@@ -68,7 +68,7 @@ def _scan_artifacts(coder_ws: Path, ws_root: Path) -> list[dict]:
             if "__pycache__" not in f.parts and f.name not in _IGNORED:
                 artifacts.append({
                     "tipo": "teste",
-                    "id": f.stem,
+                    "id": str(f.relative_to(tests_dir).with_suffix("")).replace("\\", "/"),
                     "path": str(f.relative_to(ws_root)).replace("\\", "/"),
                 })
 

--- a/adk/src/agents/workflow_coding_review/manifest.py
+++ b/adk/src/agents/workflow_coding_review/manifest.py
@@ -78,7 +78,7 @@ def _scan_artifacts(coder_ws: Path, ws_root: Path) -> list[dict]:
             if f.is_file() and f.name in _CONFIG_FILES:
                 artifacts.append({
                     "tipo": "config",
-                    "id": f.stem,
+                    "id": f.name,
                     "path": str(f.relative_to(ws_root)).replace("\\", "/"),
                 })
 

--- a/adk/src/agents/workflow_coding_review/manifest.py
+++ b/adk/src/agents/workflow_coding_review/manifest.py
@@ -112,7 +112,9 @@ def _scan_doubts(coder_ws: Path, ws_root: Path) -> list[dict]:
             text = f.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             continue
-        bloqueante = "**Bloqueante:** Sim" in text
+        # Detecta dois formatos: padrão Time 1 ("**Bloqueante:** Sim") e
+        # formato gerado por tool_gerar_doubt_artifact_adk ("EXECUÇÃO PAUSADA").
+        bloqueante = "**Bloqueante:** Sim" in text or "EXECUÇÃO PAUSADA" in text
         doubts.append({
             "id": f.stem,
             "severidade": "alta" if bloqueante else "media",

--- a/adk/src/agents/workflow_coding_review/manifest.py
+++ b/adk/src/agents/workflow_coding_review/manifest.py
@@ -96,15 +96,18 @@ def _scan_artifacts(coder_ws: Path, ws_root: Path) -> list[dict]:
 
 
 def _scan_doubts(coder_ws: Path, ws_root: Path) -> list[dict]:
-    """Varre o workspace de coding por Doubt_Artifact_*.md.
+    """Varre por Doubt_Artifact_*.md nos locais do workflow de coding.
 
     tool_gerar_doubt_artifact_adk escreve em ws_root/Doubt_Artifact_*.md
-    (raiz do workspace), não dentro de coder/. O scan parte de ws_root
-    para cobrir ambos os casos. O marcador de bloqueante é
+    (raiz do workspace). O scan cobre a raiz (não recursivo) e o interior
+    de coder/ (recursivo), evitando capturar doubts de outras fases
+    (requirements/, design/, etc.). O marcador de bloqueante é
     '**Bloqueante:** Sim' (mesmo padrão do Time 1).
     """
+    candidates = set(ws_root.glob("Doubt_Artifact_*.md"))
+    candidates |= set(coder_ws.rglob("Doubt_Artifact_*.md"))
     doubts: list[dict] = []
-    for f in sorted(ws_root.rglob("Doubt_Artifact_*.md")):
+    for f in sorted(candidates):
         try:
             text = f.read_text(encoding="utf-8", errors="ignore")
         except OSError:

--- a/adk/tests/unit/test_coding_manifest.py
+++ b/adk/tests/unit/test_coding_manifest.py
@@ -1,8 +1,8 @@
 """Testes do emissor de manifesto — Fase de Codificação (Time 4).
-
+ 
 Cobre:
 - Constantes: PHASE_NAME, STATE_KEY
-- _scan_artifacts: classificação por subpasta (codigo, teste, config, revisao),
+- _scan_artifacts: classificação por subpasta (codigo, teste, config, revisao, task),
   filtros (__pycache__, .pyc, manifest.json), path com barra forward
 - _scan_doubts: detecção de Doubt_Artifact_*.md e marcador de bloqueante
 - _validation_verdict: pass / fail / absent a partir de arquivos do reviewer
@@ -11,11 +11,11 @@ Cobre:
 - emit_coding_manifest: escrita em state + disco, degradação silenciosa
 - Wiring: after_agent_callback no SequentialAgent raiz
 """
-
+ 
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
+ 
 from src.agents.workflow_coding_review.manifest import (
     PHASE_NAME,
     STATE_KEY,
@@ -26,43 +26,43 @@ from src.agents.workflow_coding_review.manifest import (
     _validation_verdict,
     emit_coding_manifest,
 )
-
-
+ 
+ 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
+ 
+ 
 def _make_ws(tmp_path: Path, files: dict[str, str]) -> Path:
     for rel, content in files.items():
         p = tmp_path / rel
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content, encoding="utf-8")
     return tmp_path
-
-
+ 
+ 
 # ---------------------------------------------------------------------------
 # Constantes
 # ---------------------------------------------------------------------------
-
-
+ 
+ 
 def test_phase_name_canonico():
     assert PHASE_NAME == "coding"
-
-
+ 
+ 
 def test_state_key_correto():
     assert STATE_KEY == "coding_manifest"
-
-
+ 
+ 
 # ---------------------------------------------------------------------------
 # _scan_artifacts
 # ---------------------------------------------------------------------------
-
-
+ 
+ 
 def test_scan_artifacts_workspace_vazio(tmp_path):
     assert _scan_artifacts(tmp_path, tmp_path) == []
-
-
+ 
+ 
 def test_scan_artifacts_detecta_codigo(tmp_path):
     _make_ws(tmp_path, {
         "src/app/main.py": "# main",
@@ -72,16 +72,16 @@ def test_scan_artifacts_detecta_codigo(tmp_path):
     assert all(a["tipo"] == "codigo" for a in arts)
     ids = {a["id"] for a in arts}
     assert {"main", "models"} == ids
-
-
+ 
+ 
 def test_scan_artifacts_detecta_teste(tmp_path):
     _make_ws(tmp_path, {"src/tests/test_main.py": "# test"})
     arts = _scan_artifacts(tmp_path, tmp_path)
     assert len(arts) == 1
     assert arts[0]["tipo"] == "teste"
     assert arts[0]["id"] == "test_main"
-
-
+ 
+ 
 def test_scan_artifacts_detecta_config(tmp_path):
     _make_ws(tmp_path, {
         "src/Dockerfile": "FROM python:3.12-slim",
@@ -93,24 +93,35 @@ def test_scan_artifacts_detecta_config(tmp_path):
     assert tipos == {"config"}
     assert "Dockerfile" in ids
     assert "requirements.txt" in ids
-
-
+ 
+ 
 def test_scan_artifacts_detecta_revisao(tmp_path):
     _make_ws(tmp_path, {"review/verificacao_revisao.md": "## Status: APROVADO"})
     arts = _scan_artifacts(tmp_path, tmp_path)
     assert len(arts) == 1
     assert arts[0]["tipo"] == "revisao"
     assert arts[0]["id"] == "verificacao_revisao"
-
-
+ 
+ 
+def test_scan_artifacts_detecta_tasks(tmp_path):
+    _make_ws(tmp_path, {
+        "tasks/TASK-001.json": '{"id": "TASK-001"}',
+        "tasks/TASK-002.json": '{"id": "TASK-002"}',
+    })
+    arts = _scan_artifacts(tmp_path, tmp_path)
+    assert all(a["tipo"] == "task" for a in arts)
+    ids = {a["id"] for a in arts}
+    assert {"TASK-001", "TASK-002"} == ids
+ 
+ 
 def test_scan_artifacts_path_usa_barra_forward(tmp_path):
     _make_ws(tmp_path, {"src/app/main.py": "# main"})
     arts = _scan_artifacts(tmp_path, tmp_path)
     assert len(arts) == 1
     assert "\\" not in arts[0]["path"]
     assert "src/app/main.py" == arts[0]["path"]
-
-
+ 
+ 
 def test_scan_artifacts_ignora_pycache(tmp_path):
     _make_ws(tmp_path, {"src/app/main.py": "# main"})
     cache = tmp_path / "src" / "app" / "__pycache__"
@@ -119,8 +130,8 @@ def test_scan_artifacts_ignora_pycache(tmp_path):
     arts = _scan_artifacts(tmp_path, tmp_path)
     assert all("__pycache__" not in a["path"] for a in arts)
     assert all(".pyc" not in a["path"] for a in arts)
-
-
+ 
+ 
 def test_scan_artifacts_ignora_manifest_json_em_review(tmp_path):
     _make_ws(tmp_path, {
         "review/manifest.json": "{}",
@@ -130,17 +141,32 @@ def test_scan_artifacts_ignora_manifest_json_em_review(tmp_path):
     ids = {a["id"] for a in arts}
     assert "manifest" not in ids
     assert "revisao" in ids
-
-
+ 
+ 
+def test_scan_artifacts_detecta_html_e_md(tmp_path):
+    """Arquivos não-.py dentro de src/ também são catalogados como config."""
+    _make_ws(tmp_path, {
+        "src/public/hello-world.html": "<html>hello world</html>",
+        "src/PLAN.md": "# Plano",
+        "src/README.md": "# Readme",
+    })
+    arts = _scan_artifacts(tmp_path, tmp_path)
+    ids = {a["id"] for a in arts}
+    assert "hello-world.html" in ids
+    assert "PLAN.md" in ids
+    assert "README.md" in ids
+    assert all(a["tipo"] == "config" for a in arts)
+ 
+ 
 # ---------------------------------------------------------------------------
 # _scan_doubts
 # ---------------------------------------------------------------------------
-
-
+ 
+ 
 def test_scan_doubts_sem_arquivos_retorna_vazio(tmp_path):
     assert _scan_doubts(tmp_path, tmp_path) == []
-
-
+ 
+ 
 def test_scan_doubts_detecta_bloqueante(tmp_path):
     _make_ws(tmp_path, {
         "tasks/Doubt_Artifact_D-001_20260723.md": (
@@ -152,14 +178,10 @@ def test_scan_doubts_detecta_bloqueante(tmp_path):
     assert doubts[0]["bloqueante"] is True
     assert doubts[0]["severidade"] == "alta"
     assert doubts[0]["id"] == "Doubt_Artifact_D-001_20260723"
-
-
+ 
+ 
 def test_scan_doubts_detecta_formato_tool_gerar_doubt_artifact(tmp_path):
-    """Doubt gerado por tool_gerar_doubt_artifact_adk na raiz do workspace.
-
-    A tool escreve 'EXECUÇÃO PAUSADA' (sem '**Bloqueante:** Sim').
-    O scanner deve reconhecer esse formato como bloqueante.
-    """
+    """Doubt gerado por tool_gerar_doubt_artifact_adk na raiz do workspace."""
     conteudo = (
         "# Doubt Artifact — Artefatos mínimos ausentes\n"
         "\n"
@@ -181,8 +203,8 @@ def test_scan_doubts_detecta_formato_tool_gerar_doubt_artifact(tmp_path):
     assert doubts[0]["bloqueante"] is True
     assert doubts[0]["severidade"] == "alta"
     assert doubts[0]["id"] == "Doubt_Artifact_context_engineer"
-
-
+ 
+ 
 def test_scan_doubts_detecta_nao_bloqueante(tmp_path):
     _make_ws(tmp_path, {
         "tasks/Doubt_Artifact_D-002_20260723.md": (
@@ -193,181 +215,181 @@ def test_scan_doubts_detecta_nao_bloqueante(tmp_path):
     assert len(doubts) == 1
     assert doubts[0]["bloqueante"] is False
     assert doubts[0]["severidade"] == "media"
-
-
+ 
+ 
 # ---------------------------------------------------------------------------
 # _validation_verdict
 # ---------------------------------------------------------------------------
-
-
+ 
+ 
 def test_validation_verdict_absent_sem_review_dir(tmp_path):
     assert _validation_verdict(tmp_path) == "absent"
-
-
+ 
+ 
 def test_validation_verdict_absent_review_dir_vazio(tmp_path):
     (tmp_path / "review").mkdir()
     assert _validation_verdict(tmp_path) == "absent"
-
-
+ 
+ 
 def test_validation_verdict_pass(tmp_path):
     _make_ws(tmp_path, {"review/revisao.md": "## Status: APROVADO\nTudo certo."})
     assert _validation_verdict(tmp_path) == "pass"
-
-
+ 
+ 
 def test_validation_verdict_fail(tmp_path):
     _make_ws(tmp_path, {"review/revisao.md": "## Status: BLOQUEADO\nErros encontrados."})
     assert _validation_verdict(tmp_path) == "fail"
-
-
+ 
+ 
 def test_validation_verdict_fail_tem_prioridade(tmp_path):
     _make_ws(tmp_path, {
         "review/r1.md": "## Status: APROVADO",
         "review/r2.md": "## Status: BLOQUEADO",
     })
     assert _validation_verdict(tmp_path) == "fail"
-
-
+ 
+ 
 # ---------------------------------------------------------------------------
 # _derive_status
 # ---------------------------------------------------------------------------
-
-
+ 
+ 
 def _art(tipo: str) -> dict:
     return {"tipo": tipo, "id": "x", "path": "p"}
-
-
+ 
+ 
 def _blocking() -> dict:
     return {"id": "D-001", "severidade": "alta", "bloqueante": True, "path": "p"}
-
-
+ 
+ 
 def _nonblocking() -> dict:
     return {"id": "D-002", "severidade": "media", "bloqueante": False, "path": "p"}
-
-
+ 
+ 
 def test_status_ok():
     assert _derive_status([_art("codigo")], [], "pass") == "ok"
-
-
+ 
+ 
 def test_status_blocked_sem_codigo():
     assert _derive_status([], [], "pass") == "blocked"
-
-
+ 
+ 
 def test_status_blocked_doubt_bloqueante():
     assert _derive_status([_art("codigo")], [_blocking()], "pass") == "blocked"
-
-
+ 
+ 
 def test_status_partial_doubt_nao_bloqueante():
     assert _derive_status([_art("codigo")], [_nonblocking()], "pass") == "partial"
-
-
+ 
+ 
 def test_status_partial_validation_fail():
     assert _derive_status([_art("codigo")], [], "fail") == "partial"
-
-
+ 
+ 
 def test_status_partial_validation_absent():
     assert _derive_status([_art("codigo")], [], "absent") == "partial"
-
-
+ 
+ 
 # ---------------------------------------------------------------------------
 # _build_summary
 # ---------------------------------------------------------------------------
-
-
+ 
+ 
 def test_summary_conta_tipos():
     arts = [_art("codigo"), _art("codigo"), _art("config")]
     s = _build_summary(arts, [], "pass")
     assert "2 codigo(s)" in s
     assert "1 config(s)" in s
-
-
+ 
+ 
 def test_summary_menciona_doubts():
     arts = [_art("codigo")]
     doubts = [_nonblocking()]
     s = _build_summary(arts, doubts, "pass")
     assert "dúvida" in s
-
-
+ 
+ 
 def test_summary_menciona_revisao():
     s = _build_summary([_art("codigo")], [], "pass")
     assert "pass" in s
-
-
+ 
+ 
 # ---------------------------------------------------------------------------
 # emit_coding_manifest
 # ---------------------------------------------------------------------------
-
-
+ 
+ 
 def test_emit_grava_state_e_arquivo(tmp_path):
     coder_ws = tmp_path / "coder"
     _make_ws(coder_ws, {
         "src/app/main.py": "# main",
         "review/revisao.md": "## Status: APROVADO",
     })
-
+ 
     ctx = MagicMock()
     ctx.state = {}
     ctx.session = MagicMock(id=None)
     ctx.session_id = None
-
+ 
     with patch("src.agents.workflow_coding_review.manifest.get_agent_workspace", return_value=coder_ws), \
          patch("src.agents.workflow_coding_review.manifest.get_workspace_root", return_value=tmp_path):
         emit_coding_manifest(callback_context=ctx)
-
+ 
     assert STATE_KEY in ctx.state
     assert ctx.state[STATE_KEY]["phase"] == PHASE_NAME
     assert ctx.state[STATE_KEY]["status"] == "ok"
-    assert (tmp_path / "coding" / "manifest.json").exists()
-
-
+    assert (coder_ws / "manifest.json").exists()
+ 
+ 
 def test_emit_manifest_json_valido(tmp_path):
     coder_ws = tmp_path / "coder"
     _make_ws(coder_ws, {"src/app/main.py": "# main"})
-
+ 
     ctx = MagicMock()
     ctx.state = {}
     ctx.session = MagicMock(id=None)
     ctx.session_id = None
-
+ 
     with patch("src.agents.workflow_coding_review.manifest.get_agent_workspace", return_value=coder_ws), \
          patch("src.agents.workflow_coding_review.manifest.get_workspace_root", return_value=tmp_path):
         emit_coding_manifest(callback_context=ctx)
-
-    data = json.loads((tmp_path / "coding" / "manifest.json").read_text(encoding="utf-8"))
+ 
+    data = json.loads((coder_ws / "manifest.json").read_text(encoding="utf-8"))
     assert data["phase"] == PHASE_NAME
     assert data["status"] == "partial"   # código sem review → partial
     assert "artifacts" in data
     assert "doubts" in data
     assert "summary" in data
-    assert "session_id" in data
-
-
+ 
+ 
 def test_emit_nao_quebra_pipeline_em_falha():
     ctx = MagicMock()
     ctx.state = {}
-
+ 
     with patch(
         "src.agents.workflow_coding_review.manifest.get_agent_workspace",
         side_effect=RuntimeError("disco cheio"),
     ):
         emit_coding_manifest(callback_context=ctx)  # não deve levantar
-
+ 
     assert STATE_KEY not in ctx.state
-
-
+ 
+ 
 # ---------------------------------------------------------------------------
 # Wiring — after_agent_callback no SequentialAgent
 # ---------------------------------------------------------------------------
-
-
+ 
+ 
 def test_sequentialagent_tem_after_agent_callback():
     from src.agents.workflow_coding_review.agent import agent
-
+ 
     assert hasattr(agent, "after_agent_callback")
     assert agent.after_agent_callback is not None
-
-
+ 
+ 
 def test_after_agent_callback_e_emit_coding_manifest():
     from src.agents.workflow_coding_review.agent import agent
     from src.agents.workflow_coding_review.manifest import emit_coding_manifest
-
+ 
     assert agent.after_agent_callback is emit_coding_manifest
+ 

--- a/adk/tests/unit/test_coding_manifest.py
+++ b/adk/tests/unit/test_coding_manifest.py
@@ -154,6 +154,35 @@ def test_scan_doubts_detecta_bloqueante(tmp_path):
     assert doubts[0]["id"] == "Doubt_Artifact_D-001_20260723"
 
 
+def test_scan_doubts_detecta_formato_tool_gerar_doubt_artifact(tmp_path):
+    """Doubt gerado por tool_gerar_doubt_artifact_adk na raiz do workspace.
+
+    A tool escreve 'EXECUÇÃO PAUSADA' (sem '**Bloqueante:** Sim').
+    O scanner deve reconhecer esse formato como bloqueante.
+    """
+    conteudo = (
+        "# Doubt Artifact — Artefatos mínimos ausentes\n"
+        "\n"
+        "> EXECUÇÃO PAUSADA — INTERVENÇÃO NECESSÁRIA\n"
+        "> Gerado pelo context_engineer em 2026-08-04 10:00:00\n"
+        "\n"
+        "## Fase Bloqueada\n"
+        "**requirements**\n"
+        "\n"
+        "## Descrição do Problema\n"
+        "Pasta requirements/ não encontrada.\n"
+        "\n"
+        "## Ação Necessária\n"
+        "Executar o pipeline de requisitos antes do coding.\n"
+    )
+    _make_ws(tmp_path, {"Doubt_Artifact_context_engineer.md": conteudo})
+    doubts = _scan_doubts(tmp_path, tmp_path)
+    assert len(doubts) == 1
+    assert doubts[0]["bloqueante"] is True
+    assert doubts[0]["severidade"] == "alta"
+    assert doubts[0]["id"] == "Doubt_Artifact_context_engineer"
+
+
 def test_scan_doubts_detecta_nao_bloqueante(tmp_path):
     _make_ws(tmp_path, {
         "tasks/Doubt_Artifact_D-002_20260723.md": (
@@ -277,6 +306,8 @@ def test_emit_grava_state_e_arquivo(tmp_path):
 
     ctx = MagicMock()
     ctx.state = {}
+    ctx.session = MagicMock(id=None)
+    ctx.session_id = None
 
     with patch("src.agents.workflow_coding_review.manifest.get_agent_workspace", return_value=coder_ws), \
          patch("src.agents.workflow_coding_review.manifest.get_workspace_root", return_value=tmp_path):
@@ -294,6 +325,8 @@ def test_emit_manifest_json_valido(tmp_path):
 
     ctx = MagicMock()
     ctx.state = {}
+    ctx.session = MagicMock(id=None)
+    ctx.session_id = None
 
     with patch("src.agents.workflow_coding_review.manifest.get_agent_workspace", return_value=coder_ws), \
          patch("src.agents.workflow_coding_review.manifest.get_workspace_root", return_value=tmp_path):
@@ -305,6 +338,7 @@ def test_emit_manifest_json_valido(tmp_path):
     assert "artifacts" in data
     assert "doubts" in data
     assert "summary" in data
+    assert "session_id" in data
 
 
 def test_emit_nao_quebra_pipeline_em_falha():

--- a/adk/tests/unit/test_coding_manifest.py
+++ b/adk/tests/unit/test_coding_manifest.py
@@ -92,7 +92,7 @@ def test_scan_artifacts_detecta_config(tmp_path):
     ids = {a["id"] for a in arts}
     assert tipos == {"config"}
     assert "Dockerfile" in ids
-    assert "requirements" in ids
+    assert "requirements.txt" in ids
 
 
 def test_scan_artifacts_detecta_revisao(tmp_path):

--- a/adk/tests/unit/test_coding_manifest.py
+++ b/adk/tests/unit/test_coding_manifest.py
@@ -1,0 +1,339 @@
+"""Testes do emissor de manifesto — Fase de Codificação (Time 4).
+
+Cobre:
+- Constantes: PHASE_NAME, STATE_KEY
+- _scan_artifacts: classificação por subpasta (codigo, teste, config, revisao),
+  filtros (__pycache__, .pyc, manifest.json), path com barra forward
+- _scan_doubts: detecção de Doubt_Artifact_*.md e marcador de bloqueante
+- _validation_verdict: pass / fail / absent a partir de arquivos do reviewer
+- _derive_status: todas as combinações de artifacts, doubts e validation
+- _build_summary: contagem por tipo, menção a doubts e revisão
+- emit_coding_manifest: escrita em state + disco, degradação silenciosa
+- Wiring: after_agent_callback no SequentialAgent raiz
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.agents.workflow_coding_review.manifest import (
+    PHASE_NAME,
+    STATE_KEY,
+    _build_summary,
+    _derive_status,
+    _scan_artifacts,
+    _scan_doubts,
+    _validation_verdict,
+    emit_coding_manifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ws(tmp_path: Path, files: dict[str, str]) -> Path:
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Constantes
+# ---------------------------------------------------------------------------
+
+
+def test_phase_name_canonico():
+    assert PHASE_NAME == "coding"
+
+
+def test_state_key_correto():
+    assert STATE_KEY == "coding_manifest"
+
+
+# ---------------------------------------------------------------------------
+# _scan_artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_scan_artifacts_workspace_vazio(tmp_path):
+    assert _scan_artifacts(tmp_path, tmp_path) == []
+
+
+def test_scan_artifacts_detecta_codigo(tmp_path):
+    _make_ws(tmp_path, {
+        "src/app/main.py": "# main",
+        "src/app/models.py": "# models",
+    })
+    arts = _scan_artifacts(tmp_path, tmp_path)
+    assert all(a["tipo"] == "codigo" for a in arts)
+    ids = {a["id"] for a in arts}
+    assert {"main", "models"} == ids
+
+
+def test_scan_artifacts_detecta_teste(tmp_path):
+    _make_ws(tmp_path, {"src/tests/test_main.py": "# test"})
+    arts = _scan_artifacts(tmp_path, tmp_path)
+    assert len(arts) == 1
+    assert arts[0]["tipo"] == "teste"
+    assert arts[0]["id"] == "test_main"
+
+
+def test_scan_artifacts_detecta_config(tmp_path):
+    _make_ws(tmp_path, {
+        "src/Dockerfile": "FROM python:3.12-slim",
+        "src/requirements.txt": "fastapi\nuvicorn[standard]",
+    })
+    arts = _scan_artifacts(tmp_path, tmp_path)
+    tipos = {a["tipo"] for a in arts}
+    ids = {a["id"] for a in arts}
+    assert tipos == {"config"}
+    assert "Dockerfile" in ids
+    assert "requirements" in ids
+
+
+def test_scan_artifacts_detecta_revisao(tmp_path):
+    _make_ws(tmp_path, {"review/verificacao_revisao.md": "## Status: APROVADO"})
+    arts = _scan_artifacts(tmp_path, tmp_path)
+    assert len(arts) == 1
+    assert arts[0]["tipo"] == "revisao"
+    assert arts[0]["id"] == "verificacao_revisao"
+
+
+def test_scan_artifacts_path_usa_barra_forward(tmp_path):
+    _make_ws(tmp_path, {"src/app/main.py": "# main"})
+    arts = _scan_artifacts(tmp_path, tmp_path)
+    assert len(arts) == 1
+    assert "\\" not in arts[0]["path"]
+    assert "src/app/main.py" == arts[0]["path"]
+
+
+def test_scan_artifacts_ignora_pycache(tmp_path):
+    _make_ws(tmp_path, {"src/app/main.py": "# main"})
+    cache = tmp_path / "src" / "app" / "__pycache__"
+    cache.mkdir(parents=True, exist_ok=True)
+    (cache / "main.cpython-312.pyc").write_bytes(b"\x00")
+    arts = _scan_artifacts(tmp_path, tmp_path)
+    assert all("__pycache__" not in a["path"] for a in arts)
+    assert all(".pyc" not in a["path"] for a in arts)
+
+
+def test_scan_artifacts_ignora_manifest_json_em_review(tmp_path):
+    _make_ws(tmp_path, {
+        "review/manifest.json": "{}",
+        "review/revisao.md": "## Status: APROVADO",
+    })
+    arts = _scan_artifacts(tmp_path, tmp_path)
+    ids = {a["id"] for a in arts}
+    assert "manifest" not in ids
+    assert "revisao" in ids
+
+
+# ---------------------------------------------------------------------------
+# _scan_doubts
+# ---------------------------------------------------------------------------
+
+
+def test_scan_doubts_sem_arquivos_retorna_vazio(tmp_path):
+    assert _scan_doubts(tmp_path, tmp_path) == []
+
+
+def test_scan_doubts_detecta_bloqueante(tmp_path):
+    _make_ws(tmp_path, {
+        "tasks/Doubt_Artifact_D-001_20260723.md": (
+            "# Dúvida\n**Bloqueante:** Sim\nDescrição da dúvida."
+        ),
+    })
+    doubts = _scan_doubts(tmp_path, tmp_path)
+    assert len(doubts) == 1
+    assert doubts[0]["bloqueante"] is True
+    assert doubts[0]["severidade"] == "alta"
+    assert doubts[0]["id"] == "Doubt_Artifact_D-001_20260723"
+
+
+def test_scan_doubts_detecta_nao_bloqueante(tmp_path):
+    _make_ws(tmp_path, {
+        "tasks/Doubt_Artifact_D-002_20260723.md": (
+            "# Dúvida\n**Bloqueante:** Não\nDescrição da dúvida."
+        ),
+    })
+    doubts = _scan_doubts(tmp_path, tmp_path)
+    assert len(doubts) == 1
+    assert doubts[0]["bloqueante"] is False
+    assert doubts[0]["severidade"] == "media"
+
+
+# ---------------------------------------------------------------------------
+# _validation_verdict
+# ---------------------------------------------------------------------------
+
+
+def test_validation_verdict_absent_sem_review_dir(tmp_path):
+    assert _validation_verdict(tmp_path) == "absent"
+
+
+def test_validation_verdict_absent_review_dir_vazio(tmp_path):
+    (tmp_path / "review").mkdir()
+    assert _validation_verdict(tmp_path) == "absent"
+
+
+def test_validation_verdict_pass(tmp_path):
+    _make_ws(tmp_path, {"review/revisao.md": "## Status: APROVADO\nTudo certo."})
+    assert _validation_verdict(tmp_path) == "pass"
+
+
+def test_validation_verdict_fail(tmp_path):
+    _make_ws(tmp_path, {"review/revisao.md": "## Status: BLOQUEADO\nErros encontrados."})
+    assert _validation_verdict(tmp_path) == "fail"
+
+
+def test_validation_verdict_fail_tem_prioridade(tmp_path):
+    _make_ws(tmp_path, {
+        "review/r1.md": "## Status: APROVADO",
+        "review/r2.md": "## Status: BLOQUEADO",
+    })
+    assert _validation_verdict(tmp_path) == "fail"
+
+
+# ---------------------------------------------------------------------------
+# _derive_status
+# ---------------------------------------------------------------------------
+
+
+def _art(tipo: str) -> dict:
+    return {"tipo": tipo, "id": "x", "path": "p"}
+
+
+def _blocking() -> dict:
+    return {"id": "D-001", "severidade": "alta", "bloqueante": True, "path": "p"}
+
+
+def _nonblocking() -> dict:
+    return {"id": "D-002", "severidade": "media", "bloqueante": False, "path": "p"}
+
+
+def test_status_ok():
+    assert _derive_status([_art("codigo")], [], "pass") == "ok"
+
+
+def test_status_blocked_sem_codigo():
+    assert _derive_status([], [], "pass") == "blocked"
+
+
+def test_status_blocked_doubt_bloqueante():
+    assert _derive_status([_art("codigo")], [_blocking()], "pass") == "blocked"
+
+
+def test_status_partial_doubt_nao_bloqueante():
+    assert _derive_status([_art("codigo")], [_nonblocking()], "pass") == "partial"
+
+
+def test_status_partial_validation_fail():
+    assert _derive_status([_art("codigo")], [], "fail") == "partial"
+
+
+def test_status_partial_validation_absent():
+    assert _derive_status([_art("codigo")], [], "absent") == "partial"
+
+
+# ---------------------------------------------------------------------------
+# _build_summary
+# ---------------------------------------------------------------------------
+
+
+def test_summary_conta_tipos():
+    arts = [_art("codigo"), _art("codigo"), _art("config")]
+    s = _build_summary(arts, [], "pass")
+    assert "2 codigo(s)" in s
+    assert "1 config(s)" in s
+
+
+def test_summary_menciona_doubts():
+    arts = [_art("codigo")]
+    doubts = [_nonblocking()]
+    s = _build_summary(arts, doubts, "pass")
+    assert "dúvida" in s
+
+
+def test_summary_menciona_revisao():
+    s = _build_summary([_art("codigo")], [], "pass")
+    assert "pass" in s
+
+
+# ---------------------------------------------------------------------------
+# emit_coding_manifest
+# ---------------------------------------------------------------------------
+
+
+def test_emit_grava_state_e_arquivo(tmp_path):
+    coder_ws = tmp_path / "coder"
+    _make_ws(coder_ws, {
+        "src/app/main.py": "# main",
+        "review/revisao.md": "## Status: APROVADO",
+    })
+
+    ctx = MagicMock()
+    ctx.state = {}
+
+    with patch("src.agents.workflow_coding_review.manifest.get_agent_workspace", return_value=coder_ws), \
+         patch("src.agents.workflow_coding_review.manifest.get_workspace_root", return_value=tmp_path):
+        emit_coding_manifest(callback_context=ctx)
+
+    assert STATE_KEY in ctx.state
+    assert ctx.state[STATE_KEY]["phase"] == PHASE_NAME
+    assert ctx.state[STATE_KEY]["status"] == "ok"
+    assert (tmp_path / "coding" / "manifest.json").exists()
+
+
+def test_emit_manifest_json_valido(tmp_path):
+    coder_ws = tmp_path / "coder"
+    _make_ws(coder_ws, {"src/app/main.py": "# main"})
+
+    ctx = MagicMock()
+    ctx.state = {}
+
+    with patch("src.agents.workflow_coding_review.manifest.get_agent_workspace", return_value=coder_ws), \
+         patch("src.agents.workflow_coding_review.manifest.get_workspace_root", return_value=tmp_path):
+        emit_coding_manifest(callback_context=ctx)
+
+    data = json.loads((tmp_path / "coding" / "manifest.json").read_text(encoding="utf-8"))
+    assert data["phase"] == PHASE_NAME
+    assert data["status"] == "partial"   # código sem review → partial
+    assert "artifacts" in data
+    assert "doubts" in data
+    assert "summary" in data
+
+
+def test_emit_nao_quebra_pipeline_em_falha():
+    ctx = MagicMock()
+    ctx.state = {}
+
+    with patch(
+        "src.agents.workflow_coding_review.manifest.get_agent_workspace",
+        side_effect=RuntimeError("disco cheio"),
+    ):
+        emit_coding_manifest(callback_context=ctx)  # não deve levantar
+
+    assert STATE_KEY not in ctx.state
+
+
+# ---------------------------------------------------------------------------
+# Wiring — after_agent_callback no SequentialAgent
+# ---------------------------------------------------------------------------
+
+
+def test_sequentialagent_tem_after_agent_callback():
+    from src.agents.workflow_coding_review.agent import agent
+
+    assert hasattr(agent, "after_agent_callback")
+    assert agent.after_agent_callback is not None
+
+
+def test_after_agent_callback_e_emit_coding_manifest():
+    from src.agents.workflow_coding_review.agent import agent
+    from src.agents.workflow_coding_review.manifest import emit_coding_manifest
+
+    assert agent.after_agent_callback is emit_coding_manifest

--- a/adk/tests/unit/test_context_engineer.py
+++ b/adk/tests/unit/test_context_engineer.py
@@ -1,31 +1,62 @@
-"""Tests para o context_engineer do workflow coding_review (cr_context_engineer) — descoberta + schemas + tools."""
+"""Tests para workflow_coding_review/context_engineer/ — descoberta + schemas + tools."""
  
 import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+ 
+import pytest
  
  
-def test_context_engineer_root_agent_importavel():
-    from src.agents.workflow_coding_review.context_engineer import agent as root_agent
-    assert root_agent is not None
-    assert root_agent.name == "cr_context_engineer"
+# -------------------------------------------------------------------
+# Helpers
+# -------------------------------------------------------------------
+ 
+def _paths_json(paths: list) -> str:
+    """Monta paths_json no formato de lista simples de strings."""
+    return json.dumps(paths)
  
  
-def test_context_engineer_tem_output_schema():
-    from src.agents.workflow_coding_review.context_engineer import agent as root_agent
-    from src.agents.workflow_coding_review.context_engineer.schemas import TasksOutput
-    assert root_agent.output_schema == TasksOutput
+# -------------------------------------------------------------------
+# Descoberta e schema do agente
+# -------------------------------------------------------------------
+ 
+def test_context_engineer_agent_importavel():
+    from src.agents.workflow_coding_review.context_engineer.agent import agent
+    assert agent is not None
+    assert agent.name == "cr_context_engineer"
  
  
 def test_context_engineer_tem_tools_esperadas():
-    from src.agents.workflow_coding_review.context_engineer import agent as root_agent
-    tool_names = {getattr(getattr(t, "func", t), "__name__", "") for t in root_agent.tools}
+    from src.agents.workflow_coding_review.context_engineer.agent import agent
+    from google.adk.tools import LongRunningFunctionTool
+    tool_names = {getattr(getattr(t, "func", t), "__name__", "") for t in agent.tools}
     assert {
         "tool_salvar_task_cr",
-        "tool_salvar_macro_context_cr",
         "tool_ler_requirements",
         "tool_ler_design",
         "tool_gerar_doubt_artifact",
+        "tool_emitir_manifesto_bloqueado",
+        "aguardar_resolucao_bloqueio",
     } <= tool_names
+    hitl_tools = [
+        t for t in agent.tools
+        if isinstance(t, LongRunningFunctionTool)
+    ]
+    assert len(hitl_tools) == 1, (
+        "Esperado exatamente 1 LongRunningFunctionTool. "
+        f"Encontrado: {len(hitl_tools)}"
+    )
  
+ 
+def test_context_engineer_sem_output_schema():
+    """GAP-00: output_schema deve estar ausente para não desabilitar tools."""
+    from src.agents.workflow_coding_review.context_engineer.agent import agent
+    assert agent.output_schema is None
+ 
+ 
+# -------------------------------------------------------------------
+# Schemas
+# -------------------------------------------------------------------
  
 def test_schemas_macro_context_minimal():
     from src.agents.workflow_coding_review.context_engineer.schemas import MacroContext
@@ -36,30 +67,6 @@ def test_schemas_macro_context_minimal():
     )
     assert mc.summary.startswith("Sistema")
     assert len(mc.tech_stack) == 2
-
-
-def test_schemas_macro_context_product_type_default():
-    """product_type é aditivo: default 'a definir' quando não informado."""
-    from src.agents.workflow_coding_review.context_engineer.schemas import MacroContext
-    mc = MacroContext(
-        summary="Biblioteca de parsing",
-        tech_stack=["Python"],
-        global_rules=["Seguir padrões do projeto"],
-    )
-    assert mc.product_type == "a definir"
-
-
-def test_schemas_macro_context_product_type_explicito():
-    """product_type aceita valor explícito não-web (ex.: library, cli)."""
-    from src.agents.workflow_coding_review.context_engineer.schemas import MacroContext
-    mc = MacroContext(
-        summary="CLI de migração de dados",
-        product_type="cli",
-        tech_stack=["Go"],
-        global_rules=["Sem dependências externas"],
-    )
-    assert mc.product_type == "cli"
-    assert mc.tech_stack == ["Go"]
  
  
 def test_schemas_task_com_contract():
@@ -109,26 +116,10 @@ def test_schemas_contract_interfaces_objeto_aceito():
     assert any("create_ensaio" in item for item in contract.interfaces)
  
  
-def test_schemas_contract_interfaces_aceita_lista_e_string():
-    from src.agents.workflow_coding_review.context_engineer.schemas import Contract
- 
-    as_list = Contract.model_validate({
-        "inputs": [],
-        "outputs": [],
-        "interfaces": ["GET /users", "DELETE /users/<id>"],
-    })
-    assert as_list.interfaces == ["GET /users", "DELETE /users/<id>"]
- 
-    as_string = Contract.model_validate({
-        "inputs": [],
-        "outputs": [],
-        "interfaces": "POST /auth/login",
-    })
-    assert as_string.interfaces == ["POST /auth/login"]
- 
- 
 def test_schemas_tasks_output_completo():
-    from src.agents.workflow_coding_review.context_engineer.schemas import TasksOutput, MacroContext, Task, Contract
+    from src.agents.workflow_coding_review.context_engineer.schemas import (
+        TasksOutput, MacroContext, Task, Contract
+    )
     output = TasksOutput(
         macro_context=MacroContext(
             summary="X",
@@ -152,89 +143,34 @@ def test_schemas_tasks_output_completo():
     assert output.macro_context.summary == "X"
  
  
-def test_tool_salvar_task_persiste_json(tmp_path, monkeypatch):
-    """tool_salvar_task escreve JSON em workspace/tasks/<id>.json."""
+# -------------------------------------------------------------------
+# tool_salvar_task_cr
+# -------------------------------------------------------------------
+ 
+def test_tool_salvar_task_cr_persiste_json(tmp_path, monkeypatch):
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
-    from shared.tools.coding_tools.context_engineer_tools import tool_salvar_task
-    task_json = json.dumps({
-        "id": "TASK-001",
-        "type": "backend",
-        "description": "Criar endpoint",
-    })
-    result = tool_salvar_task("TASK-001", task_json)
+    from shared.tools.coding_tools.context_engineer_tools import tool_salvar_task_cr
+    task_json = json.dumps({"id": "TASK-001", "type": "backend", "description": "Criar endpoint"})
+    result = tool_salvar_task_cr("TASK-001", task_json)
     assert result["sucesso"] is True
-    arquivo = tmp_path / "ws" / "tasks" / "TASK-001.json"
+    arquivo = tmp_path / "ws" / "coder" / "tasks" / "TASK-001.json"
     assert arquivo.is_file()
-    conteudo = json.loads(arquivo.read_text(encoding="utf-8"))
-    assert conteudo["id"] == "TASK-001"
  
  
-def test_tool_salvar_task_id_invalido_rejeita(tmp_path, monkeypatch):
+def test_tool_salvar_task_cr_id_invalido_rejeita(tmp_path, monkeypatch):
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
-    from shared.tools.coding_tools.context_engineer_tools import tool_salvar_task
-    result = tool_salvar_task("INVALID-001", json.dumps({"x": 1}))
+    from shared.tools.coding_tools.context_engineer_tools import tool_salvar_task_cr
+    result = tool_salvar_task_cr("INVALID-001", json.dumps({"x": 1}))
     assert result["sucesso"] is False
     assert "TASK-" in result["erro"]
-
-
-def test_tool_salvar_macro_context_persiste_json(tmp_path, monkeypatch):
-    """tool_salvar_macro_context_cr grava _macro_context.json em coder/tasks/."""
-    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
-    from shared.tools.coding_tools.context_engineer_tools import (
-        MACRO_CONTEXT_FILENAME,
-        tool_salvar_macro_context_cr,
-    )
-    macro_json = json.dumps({
-        "summary": "CLI de migração",
-        "product_type": "cli",
-        "tech_stack": ["Go"],
-        "global_rules": ["Sem dependências externas"],
-    })
-    result = tool_salvar_macro_context_cr(macro_json)
-    assert result["sucesso"] is True
-    assert result["product_type"] == "cli"
-    arquivo = tmp_path / "ws" / "coder" / "tasks" / MACRO_CONTEXT_FILENAME
-    assert arquivo.is_file()
-    conteudo = json.loads(arquivo.read_text(encoding="utf-8"))
-    assert conteudo["product_type"] == "cli"
-    assert conteudo["tech_stack"] == ["Go"]
-
-
-def test_tool_salvar_macro_context_default_product_type(tmp_path, monkeypatch):
-    """product_type ausente/vazio degrada para 'a definir' (default do schema)."""
-    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
-    from shared.tools.coding_tools.context_engineer_tools import tool_salvar_macro_context_cr
-    result = tool_salvar_macro_context_cr(json.dumps({"summary": "X", "tech_stack": []}))
-    assert result["sucesso"] is True
-    assert result["product_type"] == "a definir"
-
-
-def test_tool_salvar_macro_context_json_invalido_rejeita(tmp_path, monkeypatch):
-    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
-    from shared.tools.coding_tools.context_engineer_tools import tool_salvar_macro_context_cr
-    result = tool_salvar_macro_context_cr("not a json")
-    assert result["sucesso"] is False
-    assert "JSON inválido" in result["erro"]
-
-
-def test_tool_salvar_macro_context_nao_objeto_rejeita(tmp_path, monkeypatch):
-    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
-    from shared.tools.coding_tools.context_engineer_tools import tool_salvar_macro_context_cr
-    result = tool_salvar_macro_context_cr(json.dumps(["não", "é", "objeto"]))
-    assert result["sucesso"] is False
-    assert "objeto JSON" in result["erro"]
-
-
-def test_tool_salvar_task_json_invalido_rejeita(tmp_path, monkeypatch):
-    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
-    from shared.tools.coding_tools.context_engineer_tools import tool_salvar_task
-    result = tool_salvar_task("TASK-002", "not a json")
-    assert result["sucesso"] is False
-    assert "JSON inválido" in result["erro"] or "JSON invalido" in str(result.get("erro", ""))
  
  
-def test_tool_ler_requirements_com_hu_e_rf(tmp_path, monkeypatch):
-    """tool_ler_requirements lê com HUs e RFs — cenário completo."""
+# -------------------------------------------------------------------
+# tool_ler_requirements — via paths do manifesto
+# -------------------------------------------------------------------
+ 
+def test_tool_ler_requirements_com_paths_validos(tmp_path, monkeypatch):
+    """Lê artefatos corretamente quando paths são fornecidos como lista de strings."""
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
     pasta_hus = tmp_path / "ws" / "requirements" / "HUs"
     pasta_rfs = tmp_path / "ws" / "requirements" / "RFs"
@@ -242,75 +178,130 @@ def test_tool_ler_requirements_com_hu_e_rf(tmp_path, monkeypatch):
     pasta_rfs.mkdir(parents=True)
     (pasta_hus / "HU-001.md").write_text("# HU-001", encoding="utf-8")
     (pasta_rfs / "RF-001.md").write_text("# RF-001", encoding="utf-8")
+ 
     from shared.tools.coding_tools.context_engineer_tools import tool_ler_requirements
-    result = tool_ler_requirements()
+    paths = _paths_json([
+        "requirements/HUs/HU-001.md",
+        "requirements/RFs/RF-001.md",
+    ])
+    result = tool_ler_requirements(paths)
     assert result["sucesso"] is True
     assert result["artefatos_minimos_presentes"] is True
     assert result["tem_hu"] is True
     assert result["total_lidos"] == 2
  
  
-def test_tool_ler_requirements_so_rf_valido(tmp_path, monkeypatch):
-    """tool_ler_requirements aceita cenário com apenas RF — HU ausente não bloqueia sozinha."""
-    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
-    pasta_rfs = tmp_path / "ws" / "requirements" / "RFs"
-    pasta_rfs.mkdir(parents=True)
-    (pasta_rfs / "RF-001.md").write_text("# RF-001", encoding="utf-8")
-    from shared.tools.coding_tools.context_engineer_tools import tool_ler_requirements
-    result = tool_ler_requirements()
-    assert result["sucesso"] is True
-    assert result["artefatos_minimos_presentes"] is True
-    assert result["tem_hu"] is False
- 
- 
 def test_tool_ler_requirements_sem_rf_bloqueia(tmp_path, monkeypatch):
-    """tool_ler_requirements bloqueia quando não existe RF — único mínimo obrigatório."""
+    """Retorna artefatos_minimos_presentes=False quando não há RF."""
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
     pasta_hus = tmp_path / "ws" / "requirements" / "HUs"
     pasta_hus.mkdir(parents=True)
     (pasta_hus / "HU-001.md").write_text("# HU-001", encoding="utf-8")
+ 
     from shared.tools.coding_tools.context_engineer_tools import tool_ler_requirements
-    result = tool_ler_requirements()
+    paths = _paths_json(["requirements/HUs/HU-001.md"])
+    result = tool_ler_requirements(paths)
     assert result["sucesso"] is True
     assert result["artefatos_minimos_presentes"] is False
     assert any("RF" in msg for msg in result["artefatos_minimos_ausentes"])
  
  
-def test_tool_ler_requirements_pasta_inexistente(tmp_path, monkeypatch):
-    """tool_ler_requirements retorna erro se pasta não existe."""
+def test_tool_ler_requirements_sem_paths_bloqueia(tmp_path, monkeypatch):
+    """Retorna erro quando paths_json está vazio."""
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
     from shared.tools.coding_tools.context_engineer_tools import tool_ler_requirements
-    result = tool_ler_requirements()
+    result = tool_ler_requirements("[]")
     assert result["sucesso"] is False
-    assert "não encontrada" in result["erro"]
+    assert "Nenhum path" in result["erro"]
  
+ 
+def test_tool_ler_requirements_path_traversal_rejeitado(tmp_path, monkeypatch):
+    """Paths com .. são rejeitados."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+    from shared.tools.coding_tools.context_engineer_tools import tool_ler_requirements
+    paths = _paths_json(["../../etc/passwd"])
+    result = tool_ler_requirements(paths)
+    assert result["sucesso"] is True
+    assert result["erros_leitura"] is not None
+    assert any(".." in e or "inválido" in e for e in result["erros_leitura"])
+ 
+ 
+def test_tool_ler_requirements_so_rf_valido(tmp_path, monkeypatch):
+    """Aceita cenário com apenas RF — HU ausente não bloqueia sozinha."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+    pasta_rfs = tmp_path / "ws" / "requirements" / "RFs"
+    pasta_rfs.mkdir(parents=True)
+    (pasta_rfs / "RF-001.md").write_text("# RF-001", encoding="utf-8")
+ 
+    from shared.tools.coding_tools.context_engineer_tools import tool_ler_requirements
+    paths = _paths_json(["requirements/RFs/RF-001.md"])
+    result = tool_ler_requirements(paths)
+    assert result["sucesso"] is True
+    assert result["artefatos_minimos_presentes"] is True
+    assert result["tem_hu"] is False
+ 
+ 
+# -------------------------------------------------------------------
+# tool_ler_design — fallback direto no workspace
+# -------------------------------------------------------------------
  
 def test_tool_ler_design_com_analise(tmp_path, monkeypatch):
-    """tool_ler_design detecta analise_tecnica presente."""
+    """Detecta analise_tecnica presente no workspace."""
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
     pasta = tmp_path / "ws" / "design"
     pasta.mkdir(parents=True)
     (pasta / "analise_tecnica_HU-001.md").write_text("# Análise", encoding="utf-8")
+ 
     from shared.tools.coding_tools.context_engineer_tools import tool_ler_design
     result = tool_ler_design()
     assert result["sucesso"] is True
     assert result["artefatos_minimos_presentes"] is True
+    assert result["fallback"] is True
+    assert result["inconsistencia_detectada"] is False
+ 
+ 
+def test_tool_ler_design_detecta_inconsistencia(tmp_path, monkeypatch):
+    """Detecta inconsistência quando tem_hu=False mas existe analise_tecnica_HU."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+    pasta = tmp_path / "ws" / "design"
+    pasta.mkdir(parents=True)
+    (pasta / "analise_tecnica_HU-001.md").write_text("# Análise", encoding="utf-8")
+ 
+    from shared.tools.coding_tools.context_engineer_tools import tool_ler_design
+    result = tool_ler_design(tem_hu=False)
+    assert result["sucesso"] is True
+    assert result["inconsistencia_detectada"] is True
+ 
+ 
+def test_tool_ler_design_sem_inconsistencia_quando_tem_hu(tmp_path, monkeypatch):
+    """Não detecta inconsistência quando tem_hu=True."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+    pasta = tmp_path / "ws" / "design"
+    pasta.mkdir(parents=True)
+    (pasta / "analise_tecnica_HU-001.md").write_text("# Análise", encoding="utf-8")
+ 
+    from shared.tools.coding_tools.context_engineer_tools import tool_ler_design
+    result = tool_ler_design(tem_hu=True)
+    assert result["sucesso"] is True
+    assert result["inconsistencia_detectada"] is False
  
  
 def test_tool_ler_design_sem_analise(tmp_path, monkeypatch):
-    """tool_ler_design detecta ausência de analise_tecnica."""
+    """Detecta ausência de analise_tecnica no workspace."""
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
     pasta = tmp_path / "ws" / "design" / "diagrams"
     pasta.mkdir(parents=True)
     (pasta / "diagrama_HU-001.mmd").write_text("graph TD", encoding="utf-8")
+ 
     from shared.tools.coding_tools.context_engineer_tools import tool_ler_design
     result = tool_ler_design()
     assert result["sucesso"] is True
     assert result["artefatos_minimos_presentes"] is False
+    assert result["inconsistencia_detectada"] is False
  
  
 def test_tool_ler_design_pasta_inexistente(tmp_path, monkeypatch):
-    """tool_ler_design retorna erro se pasta não existe."""
+    """Retorna erro se pasta design não existe."""
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
     from shared.tools.coding_tools.context_engineer_tools import tool_ler_design
     result = tool_ler_design()
@@ -318,20 +309,103 @@ def test_tool_ler_design_pasta_inexistente(tmp_path, monkeypatch):
     assert "não encontrada" in result["erro"]
  
  
-def test_tool_gerar_doubt_artifact(tmp_path, monkeypatch):
-    """tool_gerar_doubt_artifact persiste arquivo .md no workspace."""
+# -------------------------------------------------------------------
+# tool_gerar_doubt_artifact
+# -------------------------------------------------------------------
+ 
+def test_tool_gerar_doubt_artifact_na_raiz(tmp_path, monkeypatch):
+    """Persiste arquivo .md na raiz do workspace."""
     monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
     (tmp_path / "ws").mkdir(parents=True)
     from shared.tools.coding_tools.context_engineer_tools import tool_gerar_doubt_artifact
     result = tool_gerar_doubt_artifact(
-        titulo="Artefatos mínimos ausentes",
+        titulo="Manifesto de requirements não encontrado",
         fase_bloqueada="requirements",
-        descricao="Nenhum RF encontrado na pasta requirements/RFs/",
-        acao_necessaria="Reprocessar a fase requirements",
+        descricao="O orquestrador não repassou o manifesto no prompt.",
+        acao_necessaria="Reprocessar a fase requirements antes de continuar.",
     )
     assert result["sucesso"] is True
-    assert result["fase_bloqueada"] == "requirements"
     arquivo = tmp_path / "ws" / "Doubt_Artifact_context_engineer.md"
     assert arquivo.is_file()
-    conteudo = arquivo.read_text(encoding="utf-8")
-    assert "requirements" in conteudo
+ 
+ 
+def test_tool_gerar_doubt_artifact_em_subdir(tmp_path, monkeypatch):
+    """Persiste arquivo .md em subdiretório especificado."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+    (tmp_path / "ws").mkdir(parents=True)
+    from shared.tools.coding_tools.context_engineer_tools import tool_gerar_doubt_artifact
+    result = tool_gerar_doubt_artifact(
+        titulo="Fase bloqueada",
+        fase_bloqueada="requirements",
+        descricao="Bloqueio detectado.",
+        acao_necessaria="Reprocessar.",
+        subdir="coder",
+    )
+    assert result["sucesso"] is True
+    arquivo = tmp_path / "ws" / "coder" / "Doubt_Artifact_context_engineer.md"
+    assert arquivo.is_file()
+ 
+ 
+# -------------------------------------------------------------------
+# tool_emitir_manifesto_bloqueado
+# -------------------------------------------------------------------
+ 
+def test_tool_emitir_manifesto_bloqueado_grava_disco_e_state(tmp_path, monkeypatch):
+    """Grava manifesto com status=blocked em disco e no state via tool_context."""
+    monkeypatch.setenv("WORKSPACE_OUTPUT_DIR", str(tmp_path / "ws"))
+    coder_ws = tmp_path / "ws" / "coder"
+    coder_ws.mkdir(parents=True)
+ 
+    tool_ctx = MagicMock()
+    tool_ctx.state = {}
+ 
+    with patch(
+        "shared.tools.coding_tools.context_engineer_tools.get_agent_workspace",
+        return_value=coder_ws,
+    ), patch(
+        "shared.tools.coding_tools.context_engineer_tools.get_workspace_root",
+        return_value=tmp_path / "ws",
+    ):
+        from shared.tools.coding_tools.context_engineer_tools import tool_emitir_manifesto_bloqueado
+        result = tool_emitir_manifesto_bloqueado(
+            motivo="Artefatos mínimos de requisitos ausentes",
+            tool_context=tool_ctx,
+        )
+ 
+    assert result["sucesso"] is True
+    assert result["status"] == "blocked"
+    assert (coder_ws / "manifest.json").exists()
+    data = json.loads((coder_ws / "manifest.json").read_text(encoding="utf-8"))
+    assert data["phase"] == "coding"
+    assert data["status"] == "blocked"
+    assert data["summary"] == "Artefatos mínimos de requisitos ausentes"
+    assert "coding_manifest" in tool_ctx.state
+    assert tool_ctx.state["coding_manifest"]["status"] == "blocked"
+ 
+ 
+# -------------------------------------------------------------------
+# aguardar_resolucao_bloqueio (HITL)
+# -------------------------------------------------------------------
+ 
+def test_aguardar_resolucao_bloqueio_e_long_running():
+    """aguardar_resolucao_bloqueio deve ser LongRunningFunctionTool."""
+    from google.adk.tools import LongRunningFunctionTool
+    from src.agents.workflow_coding_review.context_engineer.agent import agent
+    hitl_tools = [
+        t for t in agent.tools
+        if isinstance(t, LongRunningFunctionTool)
+    ]
+    assert len(hitl_tools) == 1
+    assert getattr(hitl_tools[0], "func", None).__name__ == "aguardar_resolucao_bloqueio"
+ 
+ 
+@pytest.mark.asyncio
+async def test_aguardar_resolucao_bloqueio_retorna_none():
+    """aguardar_resolucao_bloqueio retorna None para pausar o pipeline."""
+    from shared.tools.coding_tools.context_engineer_tools import aguardar_resolucao_bloqueio
+    result = await aguardar_resolucao_bloqueio(
+        fase_bloqueada="requirements",
+        motivo="Manifesto ausente",
+        acao_necessaria="Reprocessar requirements",
+    )
+    assert result is None

--- a/docs/Time_4_Codificacao/Manifesto_Fase_Coding.md
+++ b/docs/Time_4_Codificacao/Manifesto_Fase_Coding.md
@@ -165,10 +165,10 @@ Arquivos de config reconhecidos: `requirements.txt`, `Dockerfile`, `docker-compo
   "phase": "coding",
   "status": "ok | partial | blocked",
   "artifacts": [
-    { "tipo": "codigo",  "id": "main",      "path": "workspace_output/coder/src/app/main.py" },
-    { "tipo": "teste",   "id": "test_main", "path": "workspace_output/coder/src/tests/test_main.py" },
-    { "tipo": "config",  "id": "Dockerfile","path": "workspace_output/coder/src/Dockerfile" },
-    { "tipo": "revisao", "id": "verificacao_revisao", "path": "workspace_output/coder/review/verificacao_revisao.md" }
+    { "tipo": "codigo",  "id": "main",      "path": "coder/src/app/main.py" },
+    { "tipo": "teste",   "id": "test_main", "path": "coder/src/tests/test_main.py" },
+    { "tipo": "config",  "id": "Dockerfile","path": "coder/src/Dockerfile" },
+    { "tipo": "revisao", "id": "verificacao_revisao", "path": "coder/review/verificacao_revisao.md" }
   ],
   "doubts": [],
   "summary": "Fase coding concluída com status 'ok'. Artefatos: 3 codigo, 1 config, 1 revisao, 1 teste. Revisão: pass. sem doubts.",
@@ -223,7 +223,7 @@ O Time de Codificação:
 #### Regras de sanitização de saída do manifesto
 
 - O conteúdo dos artefatos NUNCA entra no manifesto — apenas `tipo`, `id` e `path`
-- `path` é sempre relativo ao pai de `workspace_output/` (nunca absoluto)
+- `path` é sempre relativo à raiz do workspace (`workspace_output/`) (nunca absoluto)
 - O manifesto é best-effort: qualquer falha na emissão é logada, nunca propaga exceção
 
 ---

--- a/docs/Time_4_Codificacao/Manifesto_Fase_Coding.md
+++ b/docs/Time_4_Codificacao/Manifesto_Fase_Coding.md
@@ -1,7 +1,7 @@
 # Manifesto de Fase — Time 4 (Codificação)
 
 > **Issue de origem:** [#334 — Levantamento da Necessidade do Manifesto](https://github.com/PDC-ESIA/AI4ES/issues/334)
-> **Versão:** 1.1 | **Data:** 2026-08-04 | **Autor:** Time 4 — Codificação
+> **Versão:** 1.2 | **Data:** 2026-08-13 | **Autor:** Time 4 — Codificação
 
 ---
 
@@ -9,30 +9,28 @@
 
 Este estudo analisa os manifestos dos times adjacentes para identificar a estrutura
 mínima recomendada e garantir consistência entre fases. A tabela reflete o estado
-**verificado em código** após merge com `origin/develop` em 2026-07-23, e
-**confirmado em execução real do pipeline SDLC completo** em 2026-08-04
-(`workspace_output/coding/manifest.json` gerado com 20 artefatos, `status: partial`).
+**verificado em código** após merge com `origin/develop` em 2026-08-13.
 
-> **Nota sobre fonte dos dados:** após o merge com `origin/develop`, os arquivos de
-> código de Times 1 e 3 foram inspecionados diretamente — os valores abaixo refletem
-> implementações reais, não apenas especificações de PR. Time 2 (Design) ainda não
-> possui `after_agent_callback` implementado em `workflow_design_pipeline/agent.py`.
+> **Nota sobre fonte dos dados:** os arquivos de código de Times 1 e 3 foram
+> inspecionados diretamente — os valores abaixo refletem implementações reais,
+> não apenas especificações de PR. Time 2 (Design) ainda não possui
+> `after_agent_callback` implementado em `workflow_design_pipeline/agent.py`.
 
 ### 1.1 Estrutura Comum Identificada
 
 | Dimensão | Time 1 — Requisitos | Time 2 — Design | Time 3 — QA | Time 4 — Codificação |
 |---|---|---|---|---|
 | Fase (nome canônico) | `requirements` | `design` | `qa` | `coding` |
-| Tipos de artefato | HU, RF, RNF, Glossário | analise, diagrama, prototipo, relatorio, validacao | input, teste | codigo, teste, config, revisao |
-| Detecção de doubts | `**Bloqueante:** Sim` no arquivo | `**Status:** Bloqueado` no arquivo ¹ | — (sem scan de doubts) | `**Bloqueante:** Sim` no arquivo (mesmo padrão Time 1) |
+| Tipos de artefato | HU, RF, RNF, Glossário | analise, diagrama, prototipo, relatorio, validacao | input, teste | codigo, teste, config, revisao, task |
+| Detecção de doubts | `**Bloqueante:** Sim` no arquivo | `**Status:** Bloqueado` no arquivo ¹ | — (sem scan de doubts) | `**Bloqueante:** Sim` ou `EXECUÇÃO PAUSADA` no arquivo |
 | Veredicto de validação | — (sem validator separado) | `design/validation/` (validator agent) ¹ | pytest runner (via `executar_pytest_tool`) | `coder/review/` (cr_reviewer) |
 | Status canônicos | ok / partial / blocked | ok / partial / blocked | ok / partial | ok / partial / blocked |
 | Chave no `session.state` | `requirements_manifest` | `design_manifest` ¹ | `phase_manifests` (lista) ² | `coding_manifest` |
-| Arquivo em disco | `requirements/manifest.json` | `design/manifest.json` ¹ | — (somente state) ² | `coding/manifest.json` |
-| Consumidor primário | `cr_context_engineer` (Time 4) | `cr_context_engineer` (Time 4) | orquestrador SDLC | `qa_pipeline` (Time 3) |
-| Testes unitários | **18 testes** ✅ | 14 testes ¹ | — (sem testes de manifest) | **32 testes** ✅ |
+| Arquivo em disco | `requirements/manifest.json` | `design/manifest.json` ¹ | — (somente state) ² | `coder/manifest.json` |
+| Consumidor primário | `context_engineer` (Time 4) | `context_engineer` (Time 4) | orquestrador SDLC | `qa_pipeline` (Time 3) |
+| Testes unitários | **18 testes** ✅ | 14 testes ¹ | — (sem testes de manifesto) | **36 testes** ✅ |
 | Padrão de emissão | `after_agent_callback` determinístico, zero LLM ✅ | `after_agent_callback` determinístico, zero LLM ¹ | `after_agent_callback` → `EventActions` ² | `after_agent_callback` determinístico, zero LLM ✅ |
-| Estado da implementação | ✅ Implementado e validado (PR #320) | ⚠️ Pendente (especificado em PR #315) | ✅ Implementado (sem testes dedicados) | ✅ Implementado, testado e validado em pipeline real |
+| Estado da implementação | ✅ Implementado e validado (PR #320) | ⚠️ Pendente (especificado em PR #315) | ✅ Implementado (sem testes dedicados) | ✅ Implementado e testado |
 
 > ¹ Time 2 — Design: valores baseados na especificação do PR #315. Inspeção do
 > código confirma que `workflow_design_pipeline/agent.py` ainda **não possui**
@@ -52,7 +50,6 @@ Com base nos três times analisados, um manifesto de fase DEVE conter:
 - **`artifacts`** — lista de `{tipo, id, path}` (path relativo ao workspace root, nunca conteúdo)
 - **`doubts`** — lista de `{id, severidade, bloqueante, path}` (vazio se a fase não gera doubts)
 - **`summary`** — texto legível derivado dos dados acima, sem inventar informação
-- **`session_id`** — opcional, para rastreabilidade entre sessões
 
 **Invariantes obrigatórias** (comuns a todos os times):
 - `doubt.bloqueante == true` ⇒ `status == "blocked"`
@@ -68,7 +65,7 @@ Com base nos três times analisados, um manifesto de fase DEVE conter:
 **Justificativas:**
 
 1. **Isolamento de sessão.** O ADK usa `InMemorySessionService` — o estado não flui
-   entre sessões. O `coding/manifest.json` em disco é o ÚNICO canal confiável de
+   entre sessões. O `coder/manifest.json` em disco é o ÚNICO canal confiável de
    handoff entre o pipeline de codificação e o pipeline de QA, que roda em sessão
    isolada.
 
@@ -102,30 +99,41 @@ pronto para ser testado pelo Time 3 (QA).
 ```
 Requisitos → Design → [Codificação] → QA
                             ↑
-               coding/manifest.json (consumido pelo QA)
+               coder/manifest.json (consumido pelo QA)
 ```
 
 Sub-agentes internos:
 
 | Agente | Responsabilidade |
 |---|---|
-| `cr_context_engineer` | Lê manifestos de Requisitos e Design; fragmenta em tasks contextualizadas |
-| `cr_coder` | Implementa código a partir das tasks (tools de filesystem, sem git) |
-| `cr_executor` | Builda e executa em Docker; loop de correção automática (máx. 5 iterações) |
-| `cr_reviewer` | Revisão em 4 camadas; persiste relatório com `## Status: APROVADO/BLOQUEADO` |
+| `context_engineer` | Lê manifesto de Requisitos via orquestrador; lê artefatos de Design do workspace; fragmenta em tasks contextualizadas |
+| `coder` | Implementa código a partir das tasks (tools de filesystem, sem git) |
+| `executor` | Builda e executa em Docker; loop de correção automática (máx. 5 iterações) |
+| `reviewer` | Revisão em 4 camadas; persiste relatório com `## Status: APROVADO/BLOQUEADO` |
 | `emit_coding_manifest` | `after_agent_callback` — emite manifesto determinístico ao final |
 
 ### 3.2 Entradas Esperadas
 
 | Fonte | Formato | Lida por |
 |---|---|---|
-| `workspace_output/requirements/` | Diretório de artefatos (HUs, RFs, RNFs) | `cr_context_engineer` via `tool_ler_requirements_adk` |
-| `workspace_output/design/` | Diretório de artefatos (análise técnica, diagramas) | `cr_context_engineer` via `tool_ler_design_adk` |
-| Prompt do usuário | Texto livre (via orchestrator) | `cr_context_engineer` (mensagem de entrada) |
+| Manifesto de requirements | Texto estruturado no prompt (repassado pelo orquestrador via `_build_manifest_input`) | `context_engineer` — extrai paths dos artefatos e chama `tool_ler_requirements` |
+| `workspace_output/design/` | Diretório de artefatos (análise técnica, diagramas) | `context_engineer` via `tool_ler_design` (fallback direto enquanto Time 2 não produz manifesto) |
+| Prompt do usuário | Texto livre (via orchestrator) | `context_engineer` (mensagem de entrada) |
 
-O `cr_context_engineer` lê o **conteúdo completo dos artefatos** de cada diretório via `rglob` — não apenas um manifesto de resumo. Se os manifestos de requirements (`requirements/manifest.json`) ou design (`design/manifest.json`) existirem, são lidos como mais um arquivo do diretório e o LLM usa as informações junto com os demais artefatos.
+O `context_engineer` lê o manifesto de requirements **a partir do texto do prompt**
+repassado pelo orquestrador — extrai os paths dos artefatos declarados e os lê do
+workspace via `tool_ler_requirements`. Para o design, usa fallback de leitura direta
+do workspace enquanto o Time 2 não implementar seu manifesto.
 
-> **Nota:** Os manifestos de requirements e design têm como principal consumidor o **orquestrador SDLC** — que os usa para decidir deterministicamente se pode avançar para a próxima fase. O context engineer, por ser um LLM com tools de leitura, não depende deles como entrada primária.
+**Cenários de bloqueio tratados pelo `context_engineer`:**
+
+| Cenário | Comportamento |
+|---|---|
+| Manifesto de requirements ausente no prompt | Gera Doubt Artifact + emite manifesto `blocked` + pausa via HITL |
+| Manifesto de requirements com `status=blocked` | Idem |
+| RF-*.md ausente nos artefatos de requirements | Idem |
+| `analise_tecnica_*.md` ausente no workspace de design | Idem |
+| `analise_tecnica_HU-*.md` existe no design mas não há HUs em requirements | Idem (inconsistência entre times) |
 
 ### 3.3 Saídas Produzidas
 
@@ -133,15 +141,16 @@ O `cr_context_engineer` lê o **conteúdo completo dos artefatos** de cada diret
 
 | Tipo | Path no workspace | Descrição |
 |---|---|---|
-| `codigo` | `workspace_output/coder/src/app/**/*.py` | Código-fonte Python da aplicação |
-| `teste` | `workspace_output/coder/src/tests/**/*.py` | Testes automatizados |
-| `config` | `workspace_output/coder/src/{Dockerfile,requirements.txt,…}` | Infraestrutura Docker e dependências |
+| `codigo` | `workspace_output/coder/src/app/**` | Código-fonte da aplicação (qualquer extensão) |
+| `teste` | `workspace_output/coder/src/tests/**` | Testes automatizados |
+| `config` | `workspace_output/coder/src/**` (demais arquivos) | Infraestrutura Docker, dependências e outros |
 | `revisao` | `workspace_output/coder/review/*.md` | Relatório do reviewer (APROVADO/BLOQUEADO) |
+| `task` | `workspace_output/coder/tasks/*.json` | Tasks geradas pelo context_engineer |
 
-Arquivos de config reconhecidos: `requirements.txt`, `Dockerfile`, `docker-compose.yml`,
-`docker-compose.yaml`, `conftest.py`, `.dockerignore`, `pyproject.toml`, `setup.py`, `setup.cfg`.
+> **Nota:** O `_scan_artifacts` varre `src/` inteiro sem filtro de extensão — arquivos
+> `.html`, `.md`, `.json` e outros gerados pelo coder são catalogados corretamente.
 
-#### 3.3.2 Manifesto de saída (`coding/manifest.json`)
+#### 3.3.2 Manifesto de saída (`coder/manifest.json`)
 
 ```json
 {
@@ -151,11 +160,11 @@ Arquivos de config reconhecidos: `requirements.txt`, `Dockerfile`, `docker-compo
     { "tipo": "codigo",  "id": "main",      "path": "coder/src/app/main.py" },
     { "tipo": "teste",   "id": "test_main", "path": "coder/src/tests/test_main.py" },
     { "tipo": "config",  "id": "Dockerfile","path": "coder/src/Dockerfile" },
-    { "tipo": "revisao", "id": "verificacao_revisao", "path": "coder/review/verificacao_revisao.md" }
+    { "tipo": "revisao", "id": "verificacao_revisao", "path": "coder/review/verificacao_revisao.md" },
+    { "tipo": "task",    "id": "TASK-001",  "path": "coder/tasks/TASK-001.json" }
   ],
   "doubts": [],
-  "summary": "Fase coding concluída com status 'ok'. Artefatos: 3 codigo, 1 config, 1 revisao, 1 teste. Revisão: pass. sem doubts.",
-  "session_id": "<session-id-opcional>"
+  "summary": "Fase coding concluída com status 'ok'. Artefatos: 3 codigo, 1 config, 1 revisao, 1 task, 1 teste. Revisão: pass."
 }
 ```
 
@@ -175,15 +184,23 @@ Arquivos de config reconhecidos: `requirements.txt`, `Dockerfile`, `docker-compo
 > tratar `status != "ok"` como sinal de atenção e decidir se prossegue ou
 > aguarda re-execução.
 
+**Emissão em caso de bloqueio do context_engineer:**
+
+Quando o `context_engineer` detecta um bloqueio antes de gerar tasks, o manifesto
+é emitido pela `tool_emitir_manifesto_bloqueado` diretamente no state e em disco,
+**antes** da pausa HITL via `aguardar_resolucao_bloqueio`. Isso garante que o
+manifesto com `status=blocked` esteja disponível mesmo com o pipeline pausado.
+
 ### 3.4 Limites de Atuação
 
 O Time de Codificação:
 
-- ✅ Implementa código funcional conforme tasks geradas pelo `cr_context_engineer`
+- ✅ Implementa código funcional conforme tasks geradas pelo `context_engineer`
 - ✅ Valida execução em container Docker (build + runtime + rota principal)
 - ✅ Corrige erros de execução automaticamente (máximo 5 iterações)
-- ✅ Produz relatório de revisão em 4 camadas via `cr_reviewer`
+- ✅ Produz relatório de revisão em 4 camadas via `reviewer`
 - ✅ Emite manifesto de fase estruturado ao final
+- ✅ Bloqueia o pipeline via HITL quando artefatos mínimos estão ausentes
 
 - ❌ Não decide arquitetura (responsabilidade do Time 2 — Design)
 - ❌ Não executa testes de QA (responsabilidade do Time 3)
@@ -195,7 +212,7 @@ O Time de Codificação:
 
 #### Regras de integridade do workspace
 
-- Todas as tools do `cr_coder` são bound ao path `workspace_output/coder/src/` — escrita fora desse escopo é bloqueada por `_bind_tool_to_workspace`
+- Todas as tools do `coder` são bound ao path `workspace_output/coder/src/` — escrita fora desse escopo é bloqueada por `_bind_tool_to_workspace`
 - O `WORKSPACE_OUTPUT_DIR` é configurável via variável de ambiente; caminhos relativos são resolvidos a partir do CWD
 - O workspace é limpo a cada nova sessão (`init_workspace`) — sem herança de estado entre execuções
 
@@ -210,6 +227,7 @@ O Time de Codificação:
 
 - O conteúdo dos artefatos NUNCA entra no manifesto — apenas `tipo`, `id` e `path`
 - `path` é sempre relativo à raiz do workspace (`workspace_output/`) (nunca absoluto)
+- Paths sempre usam forward slashes (`/`) — normalizado via `.replace("\\", "/")`
 - O manifesto é best-effort: qualquer falha na emissão é logada, nunca propaga exceção
 
 ---
@@ -218,15 +236,10 @@ O Time de Codificação:
 
 ### 4.1 Para o Time 2 — Design (produtor de entrada)
 
-O `cr_context_engineer` lê os artefatos de design via `tool_ler_design_adk`, que
-atualmente varre o diretório `workspace_output/design/` por completo (`rglob`). O
-`design/manifest.json`, quando presente, é lido como mais um arquivo do diretório —
-não como guia estrutural de quais arquivos ler.
-
-O objetivo arquitetural (descrito em `TIME_4_CODIFICACAO.md` seção 2) é evoluir para
-leitura manifest-guided: a tool consultaria `artifacts[].path` do manifesto de design
-para ler exatamente os artefatos declarados, sem varredura cega. Essa adaptação está
-registrada como melhoria pendente na seção 6.
+O `context_engineer` lê os artefatos de design via `tool_ler_design`, que
+atualmente varre o diretório `workspace_output/design/` por completo (fallback
+enquanto o Time 2 não produz manifesto). Quando o Time 2 implementar seu manifesto,
+a tool será atualizada para leitura manifest-guided via `artifacts[].path`.
 
 **O que o Time 2 deve garantir (situação atual):**
 - Artefatos de design acessíveis em `workspace_output/design/` ao final do pipeline
@@ -236,17 +249,18 @@ registrada como melhoria pendente na seção 6.
 
 ### 4.2 Para o Time 3 — QA (consumidor de saída)
 
-O pipeline de QA deve ler `workspace_output/coding/manifest.json` antes de rodar.
+O pipeline de QA deve ler `workspace_output/coder/manifest.json` antes de rodar.
 Os paths em `artifacts` apontam para o código produzido — o QA pode usar esses
 paths para gerar testes targetados em vez de varrer o workspace.
 
 **O que o Time 4 garante:**
-- `coding/manifest.json` sempre presente ao final do pipeline (mesmo em `blocked`)
-- Artefatos do tipo `codigo` têm paths válidos para arquivos `.py` existentes
+- `coder/manifest.json` sempre presente ao final do pipeline (mesmo em `blocked`)
+- Artefatos do tipo `codigo` têm paths válidos para arquivos existentes
 - `status == "ok"` apenas quando reviewer explicitamente aprovou
+- `coding_manifest` gravado em `session.state` para handoff via orquestrador
 
 **O que o Time 3 deve implementar:**
-- Leitura de `coding/manifest.json` no início do pipeline QA
+- Leitura de `coder/manifest.json` no início do pipeline QA
 - Gating: se `status == "blocked"`, decidir se aborta ou continua com código parcial
 - Usar `artifacts` para determinar quais módulos testar
 
@@ -259,7 +273,7 @@ Este manifesto é versionado em duas formas complementares:
 | Forma | Path | Descrição |
 |---|---|---|
 | Código (runtime) | `adk/src/agents/workflow_coding_review/manifest.py` | Implementação do emissor + schema + invariantes |
-| Testes unitários | `adk/tests/unit/test_coding_manifest.py` | 32 testes cobrindo scan de artefatos, doubts, veredicto de revisão e emissão |
+| Testes unitários | `adk/tests/unit/test_coding_manifest.py` | 36 testes cobrindo scan de artefatos, doubts, veredicto de revisão e emissão |
 | Este documento | `docs/Time_4_Codificacao/Manifesto_Fase_Coding.md` | Especificação formal (critérios, entradas, saídas, limites) |
 
 ---
@@ -277,23 +291,19 @@ tokens e produzindo testes inválidos.
 antes de invocar `qa_pipeline`. Se `blocked`, sinalizar ao usuário e aguardar
 re-execução.
 
-### 6.2 Leitura manifest-guided nas tools de entrada (prioridade: média)
+### 6.2 Leitura manifest-guided para design (prioridade: média)
 
-As tools `tool_ler_requirements_adk` e `tool_ler_design_adk` atualmente varrem os
-diretórios das fases anteriores via `rglob`, sem usar os manifestos como guia
-estrutural. O manifesto de requirements ou design, quando presente, é lido como
-mais um arquivo — não como índice de quais artefatos foram produzidos.
+A tool `tool_ler_design` atualmente usa fallback de leitura direta do workspace
+enquanto o Time 2 não produz manifesto. Quando o manifesto de design for
+implementado, a tool deve ser atualizada para leitura manifest-guided via
+`artifacts[].path`, seguindo o mesmo padrão já adotado para requirements.
 
-**Problema:** A leitura via rglob funciona na prática, mas não segue o contrato
-definido em `TIME_4_CODIFICACAO.md` (seção 2): o context engineer deveria usar
-`artifacts[].path` do manifesto para saber exatamente o que foi produzido pela
-fase anterior, sem assumir a estrutura do diretório.
+### 6.3 Integração com phase_manifests do orquestrador (prioridade: alta)
 
-**Sugestão:** Adaptar as tools para tentar leitura manifest-guided primeiro
-(`manifest.json` → `artifacts[].path`), com fallback para rglob quando o manifesto
-não existir. Isso alinha o mecanismo de entrada ao padrão já adotado na saída
-(`emit_coding_manifest`) e prepara o pipeline para a refatoração do orquestrador
-descrita em `ORQUESTRADOR.md`.
+O Time 1 grava o manifesto em `state["requirements_manifest"]` mas o orquestrador
+lê de `state["phase_manifests"]` (lista acumulada). Para o manifesto de requirements
+chegar ao `context_engineer` via prompt, o Time 1 precisa também adicionar o
+manifesto em `phase_manifests`. Isso está sendo tratado como pendência do Time 1.
 
 ---
 
@@ -304,3 +314,4 @@ descrita em `ORQUESTRADOR.md`.
 - Issue #334 — Levantamento da Necessidade do Manifesto
 - `adk/src/agents/workflow_coding_review/manifest.py` — implementação
 - `adk/shared/workspace.py` — AGENT_DIRS e paths do workspace
+

--- a/docs/Time_4_Codificacao/Manifesto_Fase_Coding.md
+++ b/docs/Time_4_Codificacao/Manifesto_Fase_Coding.md
@@ -119,8 +119,8 @@ Sub-agentes internos:
 
 | Fonte | Formato | Lida por |
 |---|---|---|
-| `workspace_output/requirements/manifest.json` | JSON — schema do manifesto de fase | `cr_context_engineer` via `before_agent_callback` |
-| `workspace_output/design/manifest.json` | JSON — schema do manifesto de fase | `cr_context_engineer` via `before_agent_callback` |
+| `workspace_output/requirements/` | Diretório de artefatos (HUs, RFs, RNFs) | `cr_context_engineer` via `tool_ler_requirements_adk` |
+| `workspace_output/design/` | Diretório de artefatos (análise técnica, diagramas) | `cr_context_engineer` via `tool_ler_design_adk` |
 | Prompt do usuário | Texto livre (via orchestrator) | `cr_context_engineer` (mensagem de entrada) |
 
 **Schema do manifesto de entrada (requirements e design):**
@@ -182,12 +182,15 @@ Arquivos de config reconhecidos: `requirements.txt`, `Dockerfile`, `docker-compo
 |---|---|
 | Há doubt com `bloqueante == true` | `blocked` |
 | Nenhum artefato do tipo `codigo` produzido | `blocked` |
+| Há qualquer doubt não-bloqueante | `partial` |
 | Reviewer retornou `## Status: APROVADO` | `ok` |
 | Qualquer outro caso (reviewer ausente, BLOQUEADO, falha) | `partial` |
 
-> **Nota para consumidores:** `partial` significa que código foi produzido mas a
-> revisão não aprovou. O QA deve tratar `status != "ok"` como sinal de atenção
-> e decidir se prossegue ou aguarda re-execução.
+> **Nota para consumidores:** `partial` significa que código foi produzido mas
+> há doubts não-bloqueantes pendentes ou a revisão não aprovou. Apenas `ok`
+> garante ausência de doubts e aprovação explícita do reviewer. O QA deve
+> tratar `status != "ok"` como sinal de atenção e decidir se prossegue ou
+> aguarda re-execução.
 
 ### 3.4 Limites de Atuação
 

--- a/docs/Time_4_Codificacao/Manifesto_Fase_Coding.md
+++ b/docs/Time_4_Codificacao/Manifesto_Fase_Coding.md
@@ -123,26 +123,9 @@ Sub-agentes internos:
 | `workspace_output/design/` | Diretório de artefatos (análise técnica, diagramas) | `cr_context_engineer` via `tool_ler_design_adk` |
 | Prompt do usuário | Texto livre (via orchestrator) | `cr_context_engineer` (mensagem de entrada) |
 
-**Schema do manifesto de entrada (requirements e design):**
+O `cr_context_engineer` lê o **conteúdo completo dos artefatos** de cada diretório via `rglob` — não apenas um manifesto de resumo. Se os manifestos de requirements (`requirements/manifest.json`) ou design (`design/manifest.json`) existirem, são lidos como mais um arquivo do diretório e o LLM usa as informações junto com os demais artefatos.
 
-```json
-{
-  "phase": "requirements | design",
-  "status": "ok | partial | blocked",
-  "artifacts": [
-    { "tipo": "<tipo>", "id": "<id>", "path": "<path-relativo>" }
-  ],
-  "doubts": [
-    { "id": "<id>", "severidade": "alta | media | baixa", "bloqueante": true, "path": "<path>" }
-  ],
-  "summary": "<texto>",
-  "session_id": "<opcional>"
-}
-```
-
-**Comportamento quando manifesto de entrada está ausente:**
-O `cr_context_engineer` injeta `"(manifesto de X não disponível)"` no prompt.
-O pipeline segue com o que o usuário forneceu diretamente.
+> **Nota:** Os manifestos de requirements e design têm como principal consumidor o **orquestrador SDLC** — que os usa para decidir deterministicamente se pode avançar para a próxima fase. O context engineer, por ser um LLM com tools de leitura, não depende deles como entrada primária.
 
 ### 3.3 Saídas Produzidas
 
@@ -235,14 +218,21 @@ O Time de Codificação:
 
 ### 4.1 Para o Time 2 — Design (produtor de entrada)
 
-O `cr_context_engineer` lê `workspace_output/design/manifest.json` antes de rodar.
-O manifesto de design deve estar presente e válido para que o contexto de
-arquitetura seja injetado no prompt do context engineer.
+O `cr_context_engineer` lê os artefatos de design via `tool_ler_design_adk`, que
+atualmente varre o diretório `workspace_output/design/` por completo (`rglob`). O
+`design/manifest.json`, quando presente, é lido como mais um arquivo do diretório —
+não como guia estrutural de quais arquivos ler.
 
-**O que o Time 2 deve garantir:**
-- `design/manifest.json` presente ao final do pipeline de design
-- Artefatos referenciados em `artifacts[].path` acessíveis no workspace
-- `status` refletindo fidedignamente o resultado da validação
+O objetivo arquitetural (descrito em `TIME_4_CODIFICACAO.md` seção 2) é evoluir para
+leitura manifest-guided: a tool consultaria `artifacts[].path` do manifesto de design
+para ler exatamente os artefatos declarados, sem varredura cega. Essa adaptação está
+registrada como melhoria pendente na seção 6.
+
+**O que o Time 2 deve garantir (situação atual):**
+- Artefatos de design acessíveis em `workspace_output/design/` ao final do pipeline
+- Pelo menos um `analise_tecnica_*.md` presente (verificação mínima da tool)
+- `design/manifest.json` presente — necessário para o gating do orquestrador e,
+  futuramente, para a leitura manifest-guided
 
 ### 4.2 Para o Time 3 — QA (consumidor de saída)
 
@@ -274,9 +264,9 @@ Este manifesto é versionado em duas formas complementares:
 
 ---
 
-## 6. Melhoria Pendente
+## 6. Melhorias Pendentes
 
-### Gating do orquestrador (prioridade: alta)
+### 6.1 Gating do orquestrador (prioridade: alta)
 
 O orquestrador ainda não lê `coding_manifest` antes de disparar o pipeline de QA.
 
@@ -286,6 +276,24 @@ tokens e produzindo testes inválidos.
 **Sugestão:** O orchestrator deve verificar `state["coding_manifest"]["status"]`
 antes de invocar `qa_pipeline`. Se `blocked`, sinalizar ao usuário e aguardar
 re-execução.
+
+### 6.2 Leitura manifest-guided nas tools de entrada (prioridade: média)
+
+As tools `tool_ler_requirements_adk` e `tool_ler_design_adk` atualmente varrem os
+diretórios das fases anteriores via `rglob`, sem usar os manifestos como guia
+estrutural. O manifesto de requirements ou design, quando presente, é lido como
+mais um arquivo — não como índice de quais artefatos foram produzidos.
+
+**Problema:** A leitura via rglob funciona na prática, mas não segue o contrato
+definido em `TIME_4_CODIFICACAO.md` (seção 2): o context engineer deveria usar
+`artifacts[].path` do manifesto para saber exatamente o que foi produzido pela
+fase anterior, sem assumir a estrutura do diretório.
+
+**Sugestão:** Adaptar as tools para tentar leitura manifest-guided primeiro
+(`manifest.json` → `artifacts[].path`), com fallback para rglob quando o manifesto
+não existir. Isso alinha o mecanismo de entrada ao padrão já adotado na saída
+(`emit_coding_manifest`) e prepara o pipeline para a refatoração do orquestrador
+descrita em `ORQUESTRADOR.md`.
 
 ---
 

--- a/docs/Time_4_Codificacao/Manifesto_Fase_Coding.md
+++ b/docs/Time_4_Codificacao/Manifesto_Fase_Coding.md
@@ -1,0 +1,295 @@
+# Manifesto de Fase — Time 4 (Codificação)
+
+> **Issue de origem:** [#334 — Levantamento da Necessidade do Manifesto](https://github.com/PDC-ESIA/AI4ES/issues/334)
+> **Versão:** 1.1 | **Data:** 2026-08-04 | **Autor:** Time 4 — Codificação
+
+---
+
+## 1. Estudo Comparativo
+
+Este estudo analisa os manifestos dos times adjacentes para identificar a estrutura
+mínima recomendada e garantir consistência entre fases. A tabela reflete o estado
+**verificado em código** após merge com `origin/develop` em 2026-07-23, e
+**confirmado em execução real do pipeline SDLC completo** em 2026-08-04
+(`workspace_output/coding/manifest.json` gerado com 20 artefatos, `status: partial`).
+
+> **Nota sobre fonte dos dados:** após o merge com `origin/develop`, os arquivos de
+> código de Times 1 e 3 foram inspecionados diretamente — os valores abaixo refletem
+> implementações reais, não apenas especificações de PR. Time 2 (Design) ainda não
+> possui `after_agent_callback` implementado em `workflow_design_pipeline/agent.py`.
+
+### 1.1 Estrutura Comum Identificada
+
+| Dimensão | Time 1 — Requisitos | Time 2 — Design | Time 3 — QA | Time 4 — Codificação |
+|---|---|---|---|---|
+| Fase (nome canônico) | `requirements` | `design` | `qa` | `coding` |
+| Tipos de artefato | HU, RF, RNF, Glossário | analise, diagrama, prototipo, relatorio, validacao | input, teste | codigo, teste, config, revisao |
+| Detecção de doubts | `**Bloqueante:** Sim` no arquivo | `**Status:** Bloqueado` no arquivo ¹ | — (sem scan de doubts) | `**Bloqueante:** Sim` no arquivo (mesmo padrão Time 1) |
+| Veredicto de validação | — (sem validator separado) | `design/validation/` (validator agent) ¹ | pytest runner (via `executar_pytest_tool`) | `coder/review/` (cr_reviewer) |
+| Status canônicos | ok / partial / blocked | ok / partial / blocked | ok / partial | ok / partial / blocked |
+| Chave no `session.state` | `requirements_manifest` | `design_manifest` ¹ | `phase_manifests` (lista) ² | `coding_manifest` |
+| Arquivo em disco | `requirements/manifest.json` | `design/manifest.json` ¹ | — (somente state) ² | `coding/manifest.json` |
+| Consumidor primário | `cr_context_engineer` (Time 4) | `cr_context_engineer` (Time 4) | orquestrador SDLC | `qa_pipeline` (Time 3) |
+| Testes unitários | **18 testes** ✅ | 14 testes ¹ | — (sem testes de manifest) | **32 testes** ✅ |
+| Padrão de emissão | `after_agent_callback` determinístico, zero LLM ✅ | `after_agent_callback` determinístico, zero LLM ¹ | `after_agent_callback` → `EventActions` ² | `after_agent_callback` determinístico, zero LLM ✅ |
+| Estado da implementação | ✅ Implementado e validado (PR #320) | ⚠️ Pendente (especificado em PR #315) | ✅ Implementado (sem testes dedicados) | ✅ Implementado, testado e validado em pipeline real |
+
+> ¹ Time 2 — Design: valores baseados na especificação do PR #315. Inspeção do
+> código confirma que `workflow_design_pipeline/agent.py` ainda **não possui**
+> `after_agent_callback` wired nem testes de manifesto.
+>
+> ² Time 3 — QA: implementado via `EventActions(state_delta=...)` em vez de
+> escrita direta no state. O manifesto acumula em `phase_manifests` (lista no state)
+> mas **não é gravado em disco como `manifest.json`** — diferença relevante para
+> consumidores que dependem de leitura do arquivo entre sessões.
+
+### 1.2 Elementos Mínimos Recomendados (extraídos do padrão)
+
+Com base nos três times analisados, um manifesto de fase DEVE conter:
+
+- **`phase`** — nome canônico da fase (string imutável por fase)
+- **`status`** — `ok | partial | blocked` (derivado deterministicamente, nunca por LLM)
+- **`artifacts`** — lista de `{tipo, id, path}` (path relativo ao workspace root, nunca conteúdo)
+- **`doubts`** — lista de `{id, severidade, bloqueante, path}` (vazio se a fase não gera doubts)
+- **`summary`** — texto legível derivado dos dados acima, sem inventar informação
+- **`session_id`** — opcional, para rastreabilidade entre sessões
+
+**Invariantes obrigatórias** (comuns a todos os times):
+- `doubt.bloqueante == true` ⇒ `status == "blocked"`
+- `status == "ok"` ⇒ nenhum doubt bloqueante E ao menos um artefato principal produzido
+- A emissão do manifesto NUNCA pode derrubar o pipeline (best-effort, fail-and-log)
+
+---
+
+## 2. Recomendação Formal
+
+**Decisão: SIM — o Time de Codificação necessita e deve manter um manifesto de fase.**
+
+**Justificativas:**
+
+1. **Isolamento de sessão.** O ADK usa `InMemorySessionService` — o estado não flui
+   entre sessões. O `coding/manifest.json` em disco é o ÚNICO canal confiável de
+   handoff entre o pipeline de codificação e o pipeline de QA, que roda em sessão
+   isolada.
+
+2. **Consistência com os demais times.** Requisitos (Time 1) e Design (Time 2) já
+   adotaram o padrão. QA (Time 3) também possui callback de manifesto em
+   desenvolvimento. Sem o manifesto de codificação, o elo central da cadeia quebra.
+
+3. **Eliminação de overflow de contexto.** O output bruto do coder pode ultrapassar
+   8 000 tokens quando passado diretamente entre agentes. O manifesto é pequeno,
+   estruturado e referencia paths — o consumidor (QA) escolhe quais arquivos ler.
+
+4. **Contrato de saída verificável.** O QA precisa saber exatamente o que foi
+   produzido (`codigo`, `teste`, `config`) e se passou pela revisão (`revisao`, com
+   status `ok`). Sem manifesto, o QA dependeria de convenções implícitas ou
+   varredura total do workspace.
+
+5. **Governança.** O status do manifesto (`ok | partial | blocked`) permite que o
+   orquestrador gate a entrada no pipeline de QA, evitando desperdício de tokens em
+   código que o próprio reviewer já reprovou.
+
+---
+
+## 3. Manifesto de Fase — Codificação
+
+### 3.1 Papel no Pipeline
+
+O Time 4 ocupa a posição central do SDLC: recebe o contexto estruturado de
+Requisitos e Design e entrega código funcional, validado em Docker e revisado,
+pronto para ser testado pelo Time 3 (QA).
+
+```
+Requisitos → Design → [Codificação] → QA
+                            ↑
+               coding/manifest.json (consumido pelo QA)
+```
+
+Sub-agentes internos:
+
+| Agente | Responsabilidade |
+|---|---|
+| `cr_context_engineer` | Lê manifestos de Requisitos e Design; fragmenta em tasks contextualizadas |
+| `cr_coder` | Implementa código a partir das tasks (tools de filesystem, sem git) |
+| `cr_executor` | Builda e executa em Docker; loop de correção automática (máx. 5 iterações) |
+| `cr_reviewer` | Revisão em 4 camadas; persiste relatório com `## Status: APROVADO/BLOQUEADO` |
+| `emit_coding_manifest` | `after_agent_callback` — emite manifesto determinístico ao final |
+
+### 3.2 Entradas Esperadas
+
+| Fonte | Formato | Lida por |
+|---|---|---|
+| `workspace_output/requirements/manifest.json` | JSON — schema do manifesto de fase | `cr_context_engineer` via `before_agent_callback` |
+| `workspace_output/design/manifest.json` | JSON — schema do manifesto de fase | `cr_context_engineer` via `before_agent_callback` |
+| Prompt do usuário | Texto livre (via orchestrator) | `cr_context_engineer` (mensagem de entrada) |
+
+**Schema do manifesto de entrada (requirements e design):**
+
+```json
+{
+  "phase": "requirements | design",
+  "status": "ok | partial | blocked",
+  "artifacts": [
+    { "tipo": "<tipo>", "id": "<id>", "path": "<path-relativo>" }
+  ],
+  "doubts": [
+    { "id": "<id>", "severidade": "alta | media | baixa", "bloqueante": true, "path": "<path>" }
+  ],
+  "summary": "<texto>",
+  "session_id": "<opcional>"
+}
+```
+
+**Comportamento quando manifesto de entrada está ausente:**
+O `cr_context_engineer` injeta `"(manifesto de X não disponível)"` no prompt.
+O pipeline segue com o que o usuário forneceu diretamente.
+
+### 3.3 Saídas Produzidas
+
+#### 3.3.1 Artefatos em disco
+
+| Tipo | Path no workspace | Descrição |
+|---|---|---|
+| `codigo` | `workspace_output/coder/src/app/**/*.py` | Código-fonte Python da aplicação |
+| `teste` | `workspace_output/coder/src/tests/**/*.py` | Testes automatizados |
+| `config` | `workspace_output/coder/src/{Dockerfile,requirements.txt,…}` | Infraestrutura Docker e dependências |
+| `revisao` | `workspace_output/coder/review/*.md` | Relatório do reviewer (APROVADO/BLOQUEADO) |
+
+Arquivos de config reconhecidos: `requirements.txt`, `Dockerfile`, `docker-compose.yml`,
+`docker-compose.yaml`, `conftest.py`, `.dockerignore`, `pyproject.toml`, `setup.py`, `setup.cfg`.
+
+#### 3.3.2 Manifesto de saída (`coding/manifest.json`)
+
+```json
+{
+  "phase": "coding",
+  "status": "ok | partial | blocked",
+  "artifacts": [
+    { "tipo": "codigo",  "id": "main",      "path": "workspace_output/coder/src/app/main.py" },
+    { "tipo": "teste",   "id": "test_main", "path": "workspace_output/coder/src/tests/test_main.py" },
+    { "tipo": "config",  "id": "Dockerfile","path": "workspace_output/coder/src/Dockerfile" },
+    { "tipo": "revisao", "id": "verificacao_revisao", "path": "workspace_output/coder/review/verificacao_revisao.md" }
+  ],
+  "doubts": [],
+  "summary": "Fase coding concluída com status 'ok'. Artefatos: 3 codigo, 1 config, 1 revisao, 1 teste. Revisão: pass. sem doubts.",
+  "session_id": "<session-id-opcional>"
+}
+```
+
+#### 3.3.3 Derivação de status (determinística)
+
+| Condição (avaliada nesta ordem) | Status |
+|---|---|
+| Há doubt com `bloqueante == true` | `blocked` |
+| Nenhum artefato do tipo `codigo` produzido | `blocked` |
+| Reviewer retornou `## Status: APROVADO` | `ok` |
+| Qualquer outro caso (reviewer ausente, BLOQUEADO, falha) | `partial` |
+
+> **Nota para consumidores:** `partial` significa que código foi produzido mas a
+> revisão não aprovou. O QA deve tratar `status != "ok"` como sinal de atenção
+> e decidir se prossegue ou aguarda re-execução.
+
+### 3.4 Limites de Atuação
+
+O Time de Codificação:
+
+- ✅ Implementa código funcional conforme tasks geradas pelo `cr_context_engineer`
+- ✅ Valida execução em container Docker (build + runtime + rota principal)
+- ✅ Corrige erros de execução automaticamente (máximo 5 iterações)
+- ✅ Produz relatório de revisão em 4 camadas via `cr_reviewer`
+- ✅ Emite manifesto de fase estruturado ao final
+
+- ❌ Não decide arquitetura (responsabilidade do Time 2 — Design)
+- ❌ Não executa testes de QA (responsabilidade do Time 3)
+- ❌ Não persiste código em git nem cria branches
+- ❌ Não acessa internet (ferramentas limitadas ao filesystem do workspace)
+- ❌ Não modifica manifestos de outras fases
+
+### 3.5 Regras de Qualidade e Segurança de Código
+
+#### Regras de integridade do workspace
+
+- Todas as tools do `cr_coder` são bound ao path `workspace_output/coder/src/` — escrita fora desse escopo é bloqueada por `_bind_tool_to_workspace`
+- O `WORKSPACE_OUTPUT_DIR` é configurável via variável de ambiente; caminhos relativos são resolvidos a partir do CWD
+- O workspace é limpo a cada nova sessão (`init_workspace`) — sem herança de estado entre execuções
+
+#### Regras de código seguro
+
+- Apenas pacotes PyPI válidos no `requirements.txt` (coder recebe instrução explícita com exemplos de erros fatais)
+- SQLAlchemy relationships EXIGEM ForeignKey correspondente no model filho
+- Todo `import X` deve ter correspondência no `requirements.txt`
+- `COPY` no Dockerfile deve referenciar apenas arquivos existentes no workspace
+
+#### Regras de sanitização de saída do manifesto
+
+- O conteúdo dos artefatos NUNCA entra no manifesto — apenas `tipo`, `id` e `path`
+- `path` é sempre relativo ao pai de `workspace_output/` (nunca absoluto)
+- O manifesto é best-effort: qualquer falha na emissão é logada, nunca propaga exceção
+
+---
+
+## 4. Contrato de Integração
+
+### 4.1 Para o Time 2 — Design (produtor de entrada)
+
+O `cr_context_engineer` lê `workspace_output/design/manifest.json` antes de rodar.
+O manifesto de design deve estar presente e válido para que o contexto de
+arquitetura seja injetado no prompt do context engineer.
+
+**O que o Time 2 deve garantir:**
+- `design/manifest.json` presente ao final do pipeline de design
+- Artefatos referenciados em `artifacts[].path` acessíveis no workspace
+- `status` refletindo fidedignamente o resultado da validação
+
+### 4.2 Para o Time 3 — QA (consumidor de saída)
+
+O pipeline de QA deve ler `workspace_output/coding/manifest.json` antes de rodar.
+Os paths em `artifacts` apontam para o código produzido — o QA pode usar esses
+paths para gerar testes targetados em vez de varrer o workspace.
+
+**O que o Time 4 garante:**
+- `coding/manifest.json` sempre presente ao final do pipeline (mesmo em `blocked`)
+- Artefatos do tipo `codigo` têm paths válidos para arquivos `.py` existentes
+- `status == "ok"` apenas quando reviewer explicitamente aprovou
+
+**O que o Time 3 deve implementar:**
+- Leitura de `coding/manifest.json` no início do pipeline QA
+- Gating: se `status == "blocked"`, decidir se aborta ou continua com código parcial
+- Usar `artifacts` para determinar quais módulos testar
+
+---
+
+## 5. Versionamento
+
+Este manifesto é versionado em duas formas complementares:
+
+| Forma | Path | Descrição |
+|---|---|---|
+| Código (runtime) | `adk/src/agents/workflow_coding_review/manifest.py` | Implementação do emissor + schema + invariantes |
+| Testes unitários | `adk/tests/unit/test_coding_manifest.py` | 32 testes cobrindo scan de artefatos, doubts, veredicto de revisão e emissão |
+| Este documento | `docs/Time_4_Codificacao/Manifesto_Fase_Coding.md` | Especificação formal (critérios, entradas, saídas, limites) |
+
+---
+
+## 6. Melhoria Pendente
+
+### Gating do orquestrador (prioridade: alta)
+
+O orquestrador ainda não lê `coding_manifest` antes de disparar o pipeline de QA.
+
+**Problema:** QA pode rodar sobre código com `status == "blocked"`, desperdiçando
+tokens e produzindo testes inválidos.
+
+**Sugestão:** O orchestrator deve verificar `state["coding_manifest"]["status"]`
+antes de invocar `qa_pipeline`. Se `blocked`, sinalizar ao usuário e aguardar
+re-execução.
+
+---
+
+## Referências
+
+- PR #315 — Time 2: add: manifesto (Design)
+- PR #320 — Time 1: feature/req/m3-manifesto-requisitos (Requisitos)
+- Issue #334 — Levantamento da Necessidade do Manifesto
+- `adk/src/agents/workflow_coding_review/manifest.py` — implementação
+- `adk/shared/workspace.py` — AGENT_DIRS e paths do workspace


### PR DESCRIPTION
## O que foi feito?
- Ajustes no manifesto e no Context Engineer para a task #334.
- Sincronização com as alterações recentes da branch develop.
- Foram feitos ajustes no caminho de gravação do manifesto e do Doubt_Artifact no workspace_output bem como a exclusão de trechos nos arquivos que ainda carregavam session_id.
- Ajustei o manifesto para refletir os arquivos que foram criados na pasta workspace_output/coder (os arquivos da pasta "tasks" não estavam sendo refletidos no manifesto)
- Para lidar com a questão do fluxo de execução seguindo mesmo com Doubt_Artifact sendo emitido pelo Context Engineer, foi criada uma nova tool: "tool_emitir_manifesto_bloqueado" e o "aguardar_resolucao_bloqueio" que utiliza o padrão LongRunningFunctionTool, nesses casos o fluxo segue:
context_engineer detecta bloqueio
  → tool_gerar_doubt_artifact
  → tool_emitir_manifesto_bloqueado
  → aguardar_resolucao_bloqueio → pausa o SequentialAgent
  → coder NÃO é chamado
  → emit_coding_manifest NÃO roda
  → manifesto bloqueado preservado no state
Essa estratégia foi adotada pois utilizando apenas o padrão LongRunningFunctionTool a execução é pausada e fica aguardando intervenção, como são casos que necessitam de reprocessamento de fases essa estratégia não seria interessante para o fluxo.

## Ponto de atenção para testar
- Foi necessário executar ajustes pontuais em adk/src/agents/requirements/manifest.py para permitir que o manifesto chegasse até o Context Engineer e pudesse ser processado por ele:
1. O manifest do Time 1 grava apenas em state["requirements_manifest"] — não adiciona em phase_manifests. O orquestrador lê phase_manifests para montar o prompt, então o manifesto nunca chega ao Context Engineer. A estratégia foi alterar o trecho:
De:
python
callback_context.state["requirements_manifest"] = manifest
Para:
python
callback_context.state["requirements_manifest"] = manifest
existing = callback_context.state.get("phase_manifests", []) or []
existing.append(manifest)
callback_context.state["phase_manifests"] = existing
2. Os paths no manifesto de Requiriments usam barras invertidas do Windows (\\) e o JSON gerado pelo LLM fica malformado.
Para isso onde os paths são adicionados aos artefatos, substitua \\ por /:
"path": str(path).replace("\\", "/")
Esses pontos foram relatados para o time de Requisitos que deram a garantia que iriam aplicar essas modificações